### PR TITLE
feat: add theme management to @guidogerb/css

### DIFF
--- a/@guidogerb/css/README.md
+++ b/@guidogerb/css/README.md
@@ -1,14 +1,73 @@
 # @guidogerb/css
 
-Shared styles & tokens.
+Shared styles, design tokens, and theme management utilities for Guido & Gerber
+web applications.
 
-- `tokens.css` — color/spacing/radius/shadow/typography scales
+- `tokens.css` — base color/spacing/radius/shadow/typography scales
 - `reset.css` — normalize baseline
-- `themes/` — optional light/dark
+- `ThemeProvider` — React provider that applies CSS variables, exposes the
+  active theme, and persists changes to local storage (with a service worker
+  notification for offline support)
+- `ThemeSelect` — ready-made selector that can be embedded in
+  `@guidogerb/header` to switch between themes and create new ones
 
-Usage:
+## Usage
 
-```ts
+```tsx
 import '@guidogerb/css/reset.css'
 import '@guidogerb/css/tokens.css'
+import { ThemeProvider, ThemeSelect } from '@guidogerb/css'
+import { Header } from '@guidogerb/header'
+
+export function AppShell({ children }) {
+  return (
+    <ThemeProvider defaultThemeId="midnight">
+      <Header
+        renderThemeToggle={() => (
+          <ThemeSelect label="Theme" createLabel="New theme" />
+        )}
+      />
+      {children}
+    </ThemeProvider>
+  )
+}
 ```
+
+### ThemeProvider props
+
+- `themes` — optional array of theme definitions to supplement or replace the
+  defaults. Each definition may include an `id`, `name`, and a `tokens` object
+  mapping CSS custom properties (`--color-bg`, `--color-primary`, …) to values.
+- `defaultThemeId` — the default theme applied when no persisted selection is
+  found (`midnight` by default).
+- `initialThemeId` — compile-time override for the active theme. Useful when a
+  tenant wants to ship a preselected theme without waiting for persisted state
+  to load in the browser.
+- `onThemeChange` — optional callback invoked whenever the active theme changes
+  (after persistence completes).
+
+The provider persists the active theme id and custom theme definitions using
+`window.localStorage`. Whenever themes are saved, a `guidogerb:css-theme-update`
+message is posted to the service worker controller (when available) so offline
+caches can react.
+
+### ThemeSelect
+
+`ThemeSelect` consumes the context exposed by `ThemeProvider` and renders:
+
+- a `<select>` listing all available base + custom themes
+- a button that reveals a simple form for creating custom color palettes
+- inputs for the primary background/text/accent token values
+
+Custom themes inherit the rest of the design tokens from the currently active
+base theme and are stored alongside the active selection. Newly created themes
+become active immediately, making it easy to wire into the header via the
+`renderThemeToggle` slot.
+
+Additional exports include:
+
+- `useTheme()` — hook to access the theme context directly
+- `DEFAULT_THEMES` / `DEFAULT_THEME_ID` — the out-of-the-box theme set
+- `createThemeId()` / `normalizeThemeDefinition()` — helpers for custom flows
+- storage helpers (`loadStoredThemes`, `saveCustomThemes`, …) if deeper control
+  is needed

--- a/@guidogerb/css/__tests__/ThemeProvider.test.jsx
+++ b/@guidogerb/css/__tests__/ThemeProvider.test.jsx
@@ -1,0 +1,137 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, beforeEach } from 'vitest'
+import {
+  CUSTOM_THEMES_STORAGE_KEY,
+  DEFAULT_THEME_ID,
+  SELECTED_THEME_STORAGE_KEY,
+  ThemeProvider,
+  ThemeSelect,
+  useTheme,
+} from '../index.js'
+
+const TestConsumer = () => {
+  const theme = useTheme()
+  return (
+    <div data-testid="theme" data-active={theme?.activeThemeId ?? ''}>
+      {theme?.activeTheme?.name ?? 'None'}
+    </div>
+  )
+}
+
+describe('ThemeProvider', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    document.documentElement.removeAttribute('data-theme')
+    document.documentElement.style.cssText = ''
+  })
+
+  it('applies the default theme on mount', async () => {
+    render(
+      <ThemeProvider>
+        <TestConsumer />
+      </ThemeProvider>,
+    )
+
+    await waitFor(() =>
+      expect(document.documentElement.getAttribute('data-theme')).toBe(DEFAULT_THEME_ID),
+    )
+
+    expect(document.documentElement.style.getPropertyValue('--color-bg')).toBe('#0b0c0f')
+    expect(screen.getByTestId('theme')).toHaveAttribute('data-active', DEFAULT_THEME_ID)
+    expect(screen.getByTestId('theme')).toHaveTextContent(/midnight/i)
+  })
+
+  it('honors the defaultThemeId prop when provided', async () => {
+    render(
+      <ThemeProvider defaultThemeId="sunrise">
+        <TestConsumer />
+      </ThemeProvider>,
+    )
+
+    await waitFor(() =>
+      expect(document.documentElement.getAttribute('data-theme')).toBe('sunrise'),
+    )
+    expect(screen.getByTestId('theme')).toHaveTextContent(/sunrise/i)
+  })
+
+  it('restores a persisted selection from storage', async () => {
+    localStorage.setItem(SELECTED_THEME_STORAGE_KEY, 'forest')
+
+    render(
+      <ThemeProvider>
+        <TestConsumer />
+      </ThemeProvider>,
+    )
+
+    await waitFor(() =>
+      expect(document.documentElement.getAttribute('data-theme')).toBe('forest'),
+    )
+    expect(screen.getByTestId('theme')).toHaveAttribute('data-active', 'forest')
+  })
+})
+
+describe('ThemeSelect', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    document.documentElement.removeAttribute('data-theme')
+    document.documentElement.style.cssText = ''
+  })
+
+  it('switches themes and persists the selection', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <ThemeProvider>
+        <ThemeSelect label="Theme" />
+      </ThemeProvider>,
+    )
+
+    const select = screen.getByLabelText('Theme')
+    await waitFor(() => expect(select).toHaveValue(DEFAULT_THEME_ID))
+
+    await user.selectOptions(select, 'sunrise')
+
+    await waitFor(() =>
+      expect(document.documentElement.getAttribute('data-theme')).toBe('sunrise'),
+    )
+
+    expect(localStorage.getItem(SELECTED_THEME_STORAGE_KEY)).toBe('sunrise')
+  })
+
+  it('creates custom themes and stores them locally', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <ThemeProvider>
+        <ThemeSelect label="Theme" />
+      </ThemeProvider>,
+    )
+
+    const createButton = screen.getByRole('button', { name: /create custom theme/i })
+    await user.click(createButton)
+
+    const nameInput = screen.getByLabelText('Theme name')
+    await user.type(nameInput, 'Ocean')
+
+    const primaryColorInput = screen.getByLabelText('Primary color')
+    fireEvent.input(primaryColorInput, { target: { value: '#1fb6ff' } })
+
+    const bgColorInput = screen.getByLabelText('Background color')
+    fireEvent.input(bgColorInput, { target: { value: '#001122' } })
+
+    await user.click(screen.getByRole('button', { name: /save theme/i }))
+
+    const select = screen.getByLabelText('Theme')
+    await waitFor(() => expect(select.value).toMatch(/^ocean/))
+
+    const storedThemes = JSON.parse(localStorage.getItem(CUSTOM_THEMES_STORAGE_KEY) ?? '[]')
+    const createdTheme = storedThemes.find((theme) => theme?.name === 'Ocean')
+
+    expect(createdTheme).toBeTruthy()
+    expect(localStorage.getItem(SELECTED_THEME_STORAGE_KEY)).toEqual(createdTheme.id)
+    await waitFor(() =>
+      expect(document.documentElement.style.getPropertyValue('--color-primary')).toBe('#1fb6ff'),
+    )
+  })
+})

--- a/@guidogerb/css/__tests__/exports.test.js
+++ b/@guidogerb/css/__tests__/exports.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { createRequire } from 'node:module'
+import * as pkg from '../index.js'
 
 const require = createRequire(import.meta.url)
 
@@ -12,5 +13,14 @@ describe('@guidogerb/css package exports', () => {
   it('exposes the tokens stylesheet via package exports', () => {
     const resolvedPath = require.resolve('@guidogerb/css/tokens.css')
     expect(resolvedPath.endsWith('tokens.css')).toBe(true)
+  })
+
+  it('exports the theme provider and helpers', () => {
+    expect(typeof pkg.ThemeProvider).toBe('function')
+    expect(typeof pkg.ThemeSelect).toBe('function')
+    expect(typeof pkg.useTheme).toBe('function')
+    expect(pkg.DEFAULT_THEME_ID).toBeTypeOf('string')
+    expect(Array.isArray(pkg.DEFAULT_THEMES)).toBe(true)
+    expect(pkg.default).toBe(pkg.ThemeProvider)
   })
 })

--- a/@guidogerb/css/index.js
+++ b/@guidogerb/css/index.js
@@ -1,2 +1,19 @@
-// Re-export library entry for consumers that import from the package root
-export default () => {}
+export { ThemeProvider } from './src/ThemeProvider.jsx'
+export { ThemeContext } from './src/ThemeContext.js'
+export { ThemeSelect } from './src/ThemeSelect.jsx'
+export { useTheme } from './src/useTheme.js'
+export {
+  DEFAULT_THEME_ID,
+  DEFAULT_THEMES,
+  createThemeId,
+  normalizeThemeDefinition,
+} from './src/themes.js'
+export {
+  CUSTOM_THEMES_STORAGE_KEY,
+  SELECTED_THEME_STORAGE_KEY,
+  loadStoredThemeId,
+  loadStoredThemes,
+  saveCustomThemes,
+  saveSelectedThemeId,
+} from './src/themeStorage.js'
+export { ThemeProvider as default } from './src/ThemeProvider.jsx'

--- a/@guidogerb/css/package.json
+++ b/@guidogerb/css/package.json
@@ -21,10 +21,16 @@
   "files": [
     "index.js",
     "reset.css",
-    "tokens.css"
+    "tokens.css",
+    "src"
   ],
+  "peerDependencies": {
+    "react": ">=19"
+  },
   "dependencies": {},
   "devDependencies": {
+    "react": "^19.1.1",
+    "react-dom": "^19.1.1",
     "vitest": "^3.2.4"
   }
 }

--- a/@guidogerb/css/src/ThemeContext.js
+++ b/@guidogerb/css/src/ThemeContext.js
@@ -1,0 +1,9 @@
+import { createContext } from 'react'
+
+/**
+ * Theme context exposing the active theme, available themes, and helpers for
+ * switching or extending the set of themes.
+ */
+export const ThemeContext = createContext(null)
+
+export default ThemeContext

--- a/@guidogerb/css/src/ThemeProvider.jsx
+++ b/@guidogerb/css/src/ThemeProvider.jsx
@@ -1,0 +1,283 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { ThemeContext } from './ThemeContext.js'
+import {
+  DEFAULT_THEME_ID,
+  DEFAULT_THEMES,
+  createThemeId,
+  normalizeThemeDefinition,
+} from './themes.js'
+import {
+  CUSTOM_THEMES_STORAGE_KEY,
+  SELECTED_THEME_STORAGE_KEY,
+  loadStoredThemeId,
+  loadStoredThemes,
+  saveCustomThemes,
+  saveSelectedThemeId,
+} from './themeStorage.js'
+
+const applyThemeToDocument = (theme) => {
+  if (typeof document === 'undefined' || !theme) return () => {}
+  const root = document.documentElement
+  const previousValues = new Map()
+
+  Object.entries(theme.tokens ?? {}).forEach(([property, value]) => {
+    previousValues.set(property, root.style.getPropertyValue(property))
+    root.style.setProperty(property, value)
+  })
+
+  root.setAttribute('data-theme', theme.id)
+
+  return () => {
+    previousValues.forEach((value, property) => {
+      if (value && value.trim().length > 0) {
+        root.style.setProperty(property, value)
+      } else {
+        root.style.removeProperty(property)
+      }
+    })
+    if (root.getAttribute('data-theme') === theme.id) {
+      root.removeAttribute('data-theme')
+    }
+  }
+}
+
+const coerceThemesArray = (themes) => (Array.isArray(themes) && themes.length > 0 ? themes : DEFAULT_THEMES)
+
+/**
+ * Provides theme state, helpers, and persistence for Guido & Gerber web apps.
+ */
+export function ThemeProvider({
+  children,
+  themes = DEFAULT_THEMES,
+  defaultThemeId = DEFAULT_THEME_ID,
+  initialThemeId,
+  onThemeChange,
+} = {}) {
+  const normalizedBaseThemes = useMemo(() => {
+    const inputThemes = coerceThemesArray(themes)
+    const seen = new Set()
+    let fallbackTokens = null
+    return inputThemes.map((theme, index) => {
+      const normalized = normalizeThemeDefinition(theme ?? {}, {
+        existingIds: seen,
+        fallbackName: `Theme ${index + 1}`,
+        fallbackId: `theme-${index + 1}`,
+        baseTokens: fallbackTokens ?? theme?.tokens ?? {},
+        isCustom: false,
+        source: 'base',
+      })
+      if (!fallbackTokens) {
+        fallbackTokens = normalized.tokens
+      }
+      return normalized
+    })
+  }, [themes])
+
+  const defaultBaseTokens = useMemo(() => {
+    const explicitDefault = normalizedBaseThemes.find((theme) => theme.id === defaultThemeId)
+    return explicitDefault?.tokens ?? normalizedBaseThemes[0]?.tokens ?? {}
+  }, [normalizedBaseThemes, defaultThemeId])
+
+  const [customThemes, setCustomThemes] = useState([])
+  const [hasHydratedSelection, setHasHydratedSelection] = useState(false)
+  const [activeThemeIdState, setActiveThemeIdState] = useState(() =>
+    typeof initialThemeId === 'string' && initialThemeId.trim().length > 0
+      ? initialThemeId
+      : typeof defaultThemeId === 'string' && defaultThemeId.trim().length > 0
+        ? defaultThemeId
+        : DEFAULT_THEME_ID,
+  )
+
+  const sortedCustomThemes = useMemo(
+    () =>
+      [...customThemes].sort((a, b) =>
+        (a?.name ?? '').localeCompare(b?.name ?? '', undefined, { sensitivity: 'base' }),
+      ),
+    [customThemes],
+  )
+
+  const allThemes = useMemo(
+    () => [...normalizedBaseThemes, ...sortedCustomThemes],
+    [normalizedBaseThemes, sortedCustomThemes],
+  )
+
+  const themesById = useMemo(() => {
+    const map = new Map()
+    allThemes.forEach((theme) => {
+      if (theme?.id) {
+        map.set(theme.id, theme)
+      }
+    })
+    return map
+  }, [allThemes])
+
+  const resolvedActiveTheme =
+    themesById.get(activeThemeIdState) ??
+    themesById.get(defaultThemeId) ??
+    allThemes[0] ??
+    null
+
+  const resolvedActiveThemeId = resolvedActiveTheme?.id ?? null
+
+  useEffect(() => {
+    if (!resolvedActiveThemeId || resolvedActiveThemeId === activeThemeIdState) return
+    setActiveThemeIdState(resolvedActiveThemeId)
+  }, [resolvedActiveThemeId, activeThemeIdState])
+
+  const previousThemeIdRef = useRef(null)
+
+  useEffect(() => {
+    if (!resolvedActiveTheme) return undefined
+    return applyThemeToDocument(resolvedActiveTheme)
+  }, [resolvedActiveTheme])
+
+  useEffect(() => {
+    if (!resolvedActiveThemeId || !hasHydratedSelection) return
+    saveSelectedThemeId(resolvedActiveThemeId)
+    if (previousThemeIdRef.current !== resolvedActiveThemeId) {
+      if (typeof onThemeChange === 'function' && resolvedActiveTheme) {
+        onThemeChange({ id: resolvedActiveThemeId, theme: resolvedActiveTheme })
+      }
+      previousThemeIdRef.current = resolvedActiveThemeId
+    }
+  }, [resolvedActiveThemeId, resolvedActiveTheme, onThemeChange, hasHydratedSelection])
+
+  useEffect(() => {
+    if (!customThemes) return
+    saveCustomThemes(customThemes)
+  }, [customThemes])
+
+  useEffect(() => {
+    let cancelled = false
+
+    loadStoredThemes().then((stored) => {
+      if (cancelled) return
+      const existingIds = new Set(normalizedBaseThemes.map((theme) => theme.id))
+      const normalized = []
+      stored.forEach((theme, index) => {
+        const normalizedTheme = normalizeThemeDefinition(theme ?? {}, {
+          existingIds,
+          fallbackName: `Custom theme ${index + 1}`,
+          fallbackId: `custom-theme-${index + 1}`,
+          baseTokens: defaultBaseTokens,
+          isCustom: true,
+          source: 'custom',
+        })
+        normalized.push(normalizedTheme)
+      })
+      setCustomThemes(normalized)
+    })
+
+    return () => {
+      cancelled = true
+    }
+  }, [normalizedBaseThemes, defaultBaseTokens])
+
+  useEffect(() => {
+    let cancelled = false
+    loadStoredThemeId()
+      .then((storedId) => {
+        if (cancelled) return
+        if (typeof storedId === 'string' && storedId.trim().length > 0) {
+          setActiveThemeIdState(storedId)
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setHasHydratedSelection(true)
+        }
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const setActiveThemeId = useCallback(
+    (nextId) => {
+      if (typeof nextId !== 'string' || nextId.trim().length === 0) return
+      if (!themesById.has(nextId)) return
+      setActiveThemeIdState(nextId)
+    },
+    [themesById],
+  )
+
+  const createCustomTheme = useCallback(
+    (themeDefinition, options = {}) => {
+      let normalizedTheme = null
+      setCustomThemes((previous) => {
+        const existingIds = new Set(normalizedBaseThemes.map((theme) => theme.id))
+        const candidateId =
+          typeof themeDefinition?.id === 'string' && themeDefinition.id.trim().length > 0
+            ? themeDefinition.id.trim()
+            : null
+        const candidateNameId =
+          typeof themeDefinition?.name === 'string' && themeDefinition.name.trim().length > 0
+            ? createThemeId(themeDefinition.name)
+            : null
+        const idsToReplace = new Set([candidateId, candidateNameId].filter(Boolean))
+
+        previous.forEach((theme) => {
+          if (typeof theme?.id === 'string' && theme.id.length > 0) {
+            if (idsToReplace.has(theme.id)) return
+            existingIds.add(theme.id)
+          }
+        })
+
+        normalizedTheme = normalizeThemeDefinition(themeDefinition ?? {}, {
+          existingIds,
+          fallbackName: 'Custom theme',
+          fallbackId: 'custom-theme',
+          baseTokens: options?.baseTokens ?? defaultBaseTokens,
+          isCustom: true,
+          source: 'custom',
+        })
+
+        return [
+          ...previous.filter((theme) => {
+            if (!theme?.id) return false
+            if (theme.id === normalizedTheme.id) return false
+            if (idsToReplace.has(theme.id)) return false
+            return true
+          }),
+          normalizedTheme,
+        ]
+      })
+
+      if (normalizedTheme) {
+        setActiveThemeIdState(normalizedTheme.id)
+      }
+
+      return normalizedTheme
+    },
+    [normalizedBaseThemes, defaultBaseTokens],
+  )
+
+  const contextValue = useMemo(
+    () => ({
+      baseThemes: normalizedBaseThemes,
+      customThemes: sortedCustomThemes,
+      themes: allThemes,
+      activeThemeId: resolvedActiveThemeId,
+      activeTheme: resolvedActiveTheme,
+      setActiveThemeId,
+      createCustomTheme,
+      storageKeys: {
+        customThemes: CUSTOM_THEMES_STORAGE_KEY,
+        selectedTheme: SELECTED_THEME_STORAGE_KEY,
+      },
+    }),
+    [
+      normalizedBaseThemes,
+      sortedCustomThemes,
+      allThemes,
+      resolvedActiveThemeId,
+      resolvedActiveTheme,
+      setActiveThemeId,
+      createCustomTheme,
+    ],
+  )
+
+  return <ThemeContext.Provider value={contextValue}>{children}</ThemeContext.Provider>
+}
+
+export default ThemeProvider

--- a/@guidogerb/css/src/ThemeSelect.jsx
+++ b/@guidogerb/css/src/ThemeSelect.jsx
@@ -1,0 +1,220 @@
+import { useEffect, useId, useMemo, useState } from 'react'
+import { DEFAULT_THEMES } from './themes.js'
+import { useTheme } from './useTheme.js'
+
+const BASE_CLASS = 'gg-theme-select'
+
+const CUSTOM_THEME_FIELDS = [
+  { key: '--color-bg', name: 'colorBg', label: 'Background color', default: '#0b0c0f' },
+  { key: '--color-surface', name: 'colorSurface', label: 'Surface color', default: '#111318' },
+  { key: '--color-text', name: 'colorText', label: 'Text color', default: '#e6e8ec' },
+  { key: '--color-muted', name: 'colorMuted', label: 'Muted text color', default: '#a1a7b3' },
+  { key: '--color-primary', name: 'colorPrimary', label: 'Primary color', default: '#3b82f6' },
+  {
+    key: '--color-primary-600',
+    name: 'colorPrimaryStrong',
+    label: 'Primary (emphasis) color',
+    default: '#2563eb',
+  },
+  { key: '--color-success', name: 'colorSuccess', label: 'Success color', default: '#22c55e' },
+  { key: '--color-warning', name: 'colorWarning', label: 'Warning color', default: '#f59e0b' },
+  { key: '--color-danger', name: 'colorDanger', label: 'Danger color', default: '#ef4444' },
+]
+
+const buildClassName = (...values) => values.filter(Boolean).join(' ')
+
+const sanitizeString = (value) => (typeof value === 'string' ? value : '')
+
+const getThemeTokens = (theme) => (theme?.tokens && typeof theme.tokens === 'object' ? theme.tokens : {})
+
+/**
+ * Theme selector and custom theme creation form suitable for embedding inside the header.
+ */
+export function ThemeSelect({
+  className,
+  label = 'Theme',
+  createLabel = 'Create custom theme',
+  cancelLabel = 'Cancel',
+  saveLabel = 'Save theme',
+  onThemeChange,
+  onThemeCreated,
+} = {}) {
+  const themeContext = useTheme()
+  const availableThemes = themeContext?.themes ?? []
+  const activeThemeId = themeContext?.activeThemeId ?? availableThemes[0]?.id ?? ''
+  const activeTheme = themeContext?.activeTheme ?? availableThemes.find((theme) => theme.id === activeThemeId)
+  const setActiveThemeId = themeContext?.setActiveThemeId
+  const createCustomTheme = themeContext?.createCustomTheme
+  const canCreateCustom = typeof createCustomTheme === 'function'
+
+  const baseTokens =
+    getThemeTokens(activeTheme) ??
+    getThemeTokens(availableThemes[0]) ??
+    getThemeTokens(DEFAULT_THEMES[0])
+
+  const colorDefaults = useMemo(() => {
+    const defaults = {}
+    CUSTOM_THEME_FIELDS.forEach((field) => {
+      const tokenValue = sanitizeString(baseTokens?.[field.key])
+      defaults[field.name] = tokenValue.length > 0 ? tokenValue : field.default
+    })
+    return defaults
+  }, [baseTokens])
+
+  const [isCreating, setIsCreating] = useState(false)
+  const [formState, setFormState] = useState(() => ({ name: '', ...colorDefaults }))
+
+  useEffect(() => {
+    setFormState((prev) => ({ ...prev, ...colorDefaults }))
+  }, [colorDefaults])
+
+  const controlId = useId()
+
+  if (!availableThemes || availableThemes.length === 0) {
+    return null
+  }
+
+  const handleThemeChange = (event) => {
+    const nextId = event.target.value
+    if (typeof setActiveThemeId === 'function') {
+      setActiveThemeId(nextId)
+    }
+    if (typeof onThemeChange === 'function') {
+      const nextTheme = availableThemes.find((theme) => theme.id === nextId)
+      onThemeChange({ id: nextId, theme: nextTheme ?? null })
+    }
+  }
+
+  const handleToggleCreate = () => {
+    if (!canCreateCustom) return
+
+    if (isCreating) {
+      setIsCreating(false)
+      setFormState({ name: '', ...colorDefaults })
+    } else {
+      setFormState({ name: '', ...colorDefaults })
+      setIsCreating(true)
+    }
+  }
+
+  const handleInputChange = (event) => {
+    const { name, value } = event.target
+    setFormState((prev) => ({ ...prev, [name]: value }))
+  }
+
+  const handleSubmit = (event) => {
+    event.preventDefault()
+    const trimmedName = sanitizeString(formState.name).trim()
+    if (!trimmedName) return
+    if (!canCreateCustom) return
+
+    const tokens = {}
+    CUSTOM_THEME_FIELDS.forEach((field) => {
+      const value = sanitizeString(formState[field.name]).trim()
+      if (value.length > 0) {
+        tokens[field.key] = value
+      }
+    })
+
+    const createdTheme = createCustomTheme(
+      {
+        name: trimmedName,
+        tokens,
+      },
+      { baseTokens },
+    )
+
+    if (createdTheme) {
+      setIsCreating(false)
+      setFormState({ name: '', ...colorDefaults })
+      if (typeof onThemeCreated === 'function') {
+        onThemeCreated(createdTheme)
+      }
+      if (typeof onThemeChange === 'function') {
+        onThemeChange({ id: createdTheme.id, theme: createdTheme })
+      }
+    }
+  }
+
+  const wrapperClassName = buildClassName(
+    BASE_CLASS,
+    isCreating ? `${BASE_CLASS}--is-creating` : null,
+    className,
+  )
+
+  return (
+    <div className={wrapperClassName} data-active-theme={activeThemeId}>
+      <label className={`${BASE_CLASS}__label`} htmlFor={controlId}>
+        <span className={`${BASE_CLASS}__label-text`}>{label}</span>
+        <select
+          id={controlId}
+          className={`${BASE_CLASS}__select`}
+          value={activeThemeId}
+          onChange={handleThemeChange}
+        >
+          {availableThemes.map((theme) => (
+            <option key={theme.id} value={theme.id}>
+              {theme.name}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <div className={`${BASE_CLASS}__actions`}>
+        <button
+          type="button"
+          className={`${BASE_CLASS}__toggle`}
+          onClick={handleToggleCreate}
+          aria-expanded={isCreating}
+          disabled={!canCreateCustom}
+        >
+          {isCreating ? cancelLabel : createLabel}
+        </button>
+      </div>
+
+      {isCreating ? (
+        <form className={`${BASE_CLASS}__form`} onSubmit={handleSubmit}>
+          <div className={`${BASE_CLASS}__field`}>
+            <label className={`${BASE_CLASS}__field-label`} htmlFor={`${controlId}-name`}>
+              Theme name
+            </label>
+            <input
+              id={`${controlId}-name`}
+              className={`${BASE_CLASS}__input`}
+              name="name"
+              value={formState.name}
+              onChange={handleInputChange}
+              placeholder="New theme name"
+              required
+              type="text"
+            />
+          </div>
+
+          <div className={`${BASE_CLASS}__grid`} role="group" aria-label="Theme colors">
+            {CUSTOM_THEME_FIELDS.map((field) => (
+              <label key={field.key} className={`${BASE_CLASS}__field`} htmlFor={`${controlId}-${field.name}`}>
+                <span className={`${BASE_CLASS}__field-label`}>{field.label}</span>
+                <input
+                  id={`${controlId}-${field.name}`}
+                  className={`${BASE_CLASS}__input ${BASE_CLASS}__input--color`}
+                  type="color"
+                  name={field.name}
+                  value={sanitizeString(formState[field.name])}
+                  onChange={handleInputChange}
+                />
+              </label>
+            ))}
+          </div>
+
+          <div className={`${BASE_CLASS}__form-actions`}>
+            <button type="submit" className={`${BASE_CLASS}__save`}>
+              {saveLabel}
+            </button>
+          </div>
+        </form>
+      ) : null}
+    </div>
+  )
+}
+
+export default ThemeSelect

--- a/@guidogerb/css/src/themeStorage.js
+++ b/@guidogerb/css/src/themeStorage.js
@@ -1,0 +1,132 @@
+export const CUSTOM_THEMES_STORAGE_KEY = 'gg:css:custom-themes'
+export const SELECTED_THEME_STORAGE_KEY = 'gg:css:selected-theme'
+
+const isBrowser = () => typeof window !== 'undefined'
+
+const getLocalStorage = () => {
+  if (!isBrowser()) return null
+  try {
+    return window.localStorage
+  } catch (error) {
+    return null
+  }
+}
+
+const safeJsonParse = (value) => {
+  try {
+    return JSON.parse(value)
+  } catch (error) {
+    return null
+  }
+}
+
+const sanitizeStoredThemes = (value) => {
+  if (!Array.isArray(value)) return []
+  return value
+    .map((entry) => {
+      if (!entry || typeof entry !== 'object') return null
+      const id = typeof entry.id === 'string' && entry.id.trim().length > 0 ? entry.id : null
+      const name = typeof entry.name === 'string' && entry.name.trim().length > 0 ? entry.name : null
+      if (!id && !name) return null
+      const tokens = {}
+      if (entry.tokens && typeof entry.tokens === 'object') {
+        Object.entries(entry.tokens).forEach(([key, tokenValue]) => {
+          if (tokenValue === null || tokenValue === undefined) return
+          const valueAsString =
+            typeof tokenValue === 'string'
+              ? tokenValue
+              : typeof tokenValue === 'number'
+                ? String(tokenValue)
+                : null
+          if (!valueAsString) return
+          const property = key.startsWith('--') ? key : `--${key}`
+          tokens[property] = valueAsString
+        })
+      }
+      return {
+        id: id ?? name ?? null,
+        name: name ?? id ?? 'Custom theme',
+        tokens,
+        isCustom: true,
+        source: 'custom',
+      }
+    })
+    .filter(Boolean)
+}
+
+const notifyServiceWorker = (payload) => {
+  if (typeof navigator === 'undefined' || !navigator?.serviceWorker) return
+  try {
+    if (navigator.serviceWorker.controller) {
+      navigator.serviceWorker.controller.postMessage({
+        type: 'guidogerb:css-theme-update',
+        payload,
+      })
+      return
+    }
+    const ready = navigator.serviceWorker.ready
+    if (ready && typeof ready.then === 'function') {
+      ready
+        .then((registration) => {
+          registration?.active?.postMessage({
+            type: 'guidogerb:css-theme-update',
+            payload,
+          })
+        })
+        .catch(() => void 0)
+    }
+  } catch (error) {
+    /* noop */
+  }
+}
+
+export async function loadStoredThemes() {
+  const storage = getLocalStorage()
+  if (!storage) return []
+  const raw = storage.getItem(CUSTOM_THEMES_STORAGE_KEY)
+  if (!raw) return []
+  const parsed = safeJsonParse(raw)
+  return sanitizeStoredThemes(parsed)
+}
+
+export async function saveCustomThemes(themes) {
+  const storage = getLocalStorage()
+  if (!storage) return
+  const payload = Array.isArray(themes)
+    ? themes.map((theme) => ({
+        id: theme?.id ?? null,
+        name: theme?.name ?? null,
+        tokens: theme?.tokens ?? {},
+      }))
+    : []
+  try {
+    storage.setItem(CUSTOM_THEMES_STORAGE_KEY, JSON.stringify(payload))
+  } catch (error) {
+    return
+  }
+  notifyServiceWorker({ type: 'custom-themes', themes: payload })
+}
+
+export async function loadStoredThemeId() {
+  const storage = getLocalStorage()
+  if (!storage) return null
+  const value = storage.getItem(SELECTED_THEME_STORAGE_KEY)
+  if (typeof value !== 'string' || value.trim().length === 0) return null
+  return value
+}
+
+export async function saveSelectedThemeId(themeId) {
+  const storage = getLocalStorage()
+  if (!storage) return
+  if (typeof themeId !== 'string' || themeId.trim().length === 0) {
+    storage.removeItem(SELECTED_THEME_STORAGE_KEY)
+    notifyServiceWorker({ type: 'active-theme', themeId: null })
+    return
+  }
+  try {
+    storage.setItem(SELECTED_THEME_STORAGE_KEY, themeId)
+  } catch (error) {
+    return
+  }
+  notifyServiceWorker({ type: 'active-theme', themeId })
+}

--- a/@guidogerb/css/src/themes.js
+++ b/@guidogerb/css/src/themes.js
@@ -1,0 +1,209 @@
+let autoIdCounter = 0
+
+const sanitizeName = (value, fallback) => {
+  if (typeof value === 'string' && value.trim().length > 0) {
+    return value.trim()
+  }
+  if (typeof fallback === 'string' && fallback.trim().length > 0) {
+    return fallback.trim()
+  }
+  return 'Theme'
+}
+
+const slugify = (value) => {
+  if (typeof value !== 'string') return ''
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+/, '')
+    .replace(/-+$/, '')
+}
+
+export function createThemeId(input, prefix = 'theme') {
+  const slug = slugify(typeof input === 'string' ? input : '')
+  if (slug.length > 0) return slug
+  autoIdCounter += 1
+  return `${prefix}-${autoIdCounter}`
+}
+
+const ensureUniqueId = (id, existingIds) => {
+  if (!(existingIds instanceof Set)) return id
+  if (!existingIds.has(id)) {
+    existingIds.add(id)
+    return id
+  }
+  let suffix = 2
+  let candidate = `${id}-${suffix}`
+  while (existingIds.has(candidate)) {
+    suffix += 1
+    candidate = `${id}-${suffix}`
+  }
+  existingIds.add(candidate)
+  return candidate
+}
+
+const coerceTokens = (tokens, baseTokens = {}) => {
+  const merged = { ...(baseTokens ?? {}), ...(tokens ?? {}) }
+  const normalized = {}
+  Object.entries(merged).forEach(([key, value]) => {
+    if (value === null || value === undefined) return
+    const stringValue =
+      typeof value === 'string' && value.trim().length > 0
+        ? value
+        : typeof value === 'number'
+          ? String(value)
+          : null
+    if (!stringValue) return
+    const property = key.startsWith('--') ? key : `--${key}`
+    normalized[property] = stringValue
+  })
+  return normalized
+}
+
+export function normalizeThemeDefinition(definition, options = {}) {
+  const {
+    existingIds,
+    fallbackName = 'Theme',
+    fallbackId = 'theme',
+    baseTokens = {},
+    isCustom = false,
+    source,
+  } = options ?? {}
+
+  const name = sanitizeName(definition?.name, fallbackName)
+  const idSource = sanitizeName(definition?.id, name)
+  const generatedId = createThemeId(idSource, fallbackId)
+  const id = ensureUniqueId(generatedId, existingIds)
+
+  const tokens = coerceTokens(definition?.tokens, baseTokens)
+
+  return {
+    id,
+    name,
+    tokens,
+    isCustom: Boolean(isCustom ?? definition?.isCustom),
+    source: source ?? definition?.source ?? (isCustom ? 'custom' : 'base'),
+  }
+}
+
+export const DEFAULT_THEME_ID = 'midnight'
+
+export const DEFAULT_THEMES = [
+  {
+    id: 'midnight',
+    name: 'Midnight',
+    tokens: {
+      '--color-bg': '#0b0c0f',
+      '--color-surface': '#111318',
+      '--color-text': '#e6e8ec',
+      '--color-muted': '#a1a7b3',
+      '--color-primary': '#3b82f6',
+      '--color-primary-600': '#2563eb',
+      '--color-success': '#22c55e',
+      '--color-warning': '#f59e0b',
+      '--color-danger': '#ef4444',
+      '--space-0': '0',
+      '--space-1': '4px',
+      '--space-2': '8px',
+      '--space-3': '12px',
+      '--space-4': '16px',
+      '--space-5': '20px',
+      '--space-6': '24px',
+      '--space-8': '32px',
+      '--space-10': '40px',
+      '--space-12': '48px',
+      '--radius-1': '4px',
+      '--radius-2': '8px',
+      '--radius-round': '999px',
+      '--shadow-1': '0 1px 2px rgba(0, 0, 0, 0.2)',
+      '--shadow-2': '0 4px 12px rgba(0, 0, 0, 0.25)',
+      '--font-sans':
+        "ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, 'Apple Color Emoji', 'Segoe UI Emoji'",
+      '--font-mono':
+        "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace",
+      '--text-sm': '0.875rem',
+      '--text-base': '1rem',
+      '--text-lg': '1.125rem',
+      '--text-xl': '1.25rem',
+    },
+  },
+  {
+    id: 'sunrise',
+    name: 'Sunrise',
+    tokens: {
+      '--color-bg': '#fdfcf7',
+      '--color-surface': '#ffffff',
+      '--color-text': '#1f2933',
+      '--color-muted': '#52606d',
+      '--color-primary': '#2563eb',
+      '--color-primary-600': '#1d4ed8',
+      '--color-success': '#16a34a',
+      '--color-warning': '#ca8a04',
+      '--color-danger': '#dc2626',
+      '--space-0': '0',
+      '--space-1': '4px',
+      '--space-2': '8px',
+      '--space-3': '12px',
+      '--space-4': '16px',
+      '--space-5': '20px',
+      '--space-6': '24px',
+      '--space-8': '32px',
+      '--space-10': '40px',
+      '--space-12': '48px',
+      '--radius-1': '4px',
+      '--radius-2': '8px',
+      '--radius-round': '999px',
+      '--shadow-1': '0 1px 2px rgba(15, 23, 42, 0.12)',
+      '--shadow-2': '0 8px 24px rgba(15, 23, 42, 0.16)',
+      '--font-sans':
+        "ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, 'Apple Color Emoji', 'Segoe UI Emoji'",
+      '--font-mono':
+        "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace",
+      '--text-sm': '0.875rem',
+      '--text-base': '1rem',
+      '--text-lg': '1.125rem',
+      '--text-xl': '1.25rem',
+    },
+  },
+  {
+    id: 'forest',
+    name: 'Forest',
+    tokens: {
+      '--color-bg': '#0f172a',
+      '--color-surface': '#11213c',
+      '--color-text': '#e0f2f1',
+      '--color-muted': '#81aab5',
+      '--color-primary': '#10b981',
+      '--color-primary-600': '#059669',
+      '--color-success': '#22c55e',
+      '--color-warning': '#fbbf24',
+      '--color-danger': '#f87171',
+      '--space-0': '0',
+      '--space-1': '4px',
+      '--space-2': '8px',
+      '--space-3': '12px',
+      '--space-4': '16px',
+      '--space-5': '20px',
+      '--space-6': '24px',
+      '--space-8': '32px',
+      '--space-10': '40px',
+      '--space-12': '48px',
+      '--radius-1': '4px',
+      '--radius-2': '8px',
+      '--radius-round': '999px',
+      '--shadow-1': '0 1px 2px rgba(10, 29, 49, 0.3)',
+      '--shadow-2': '0 8px 24px rgba(8, 47, 73, 0.35)',
+      '--font-sans':
+        "ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, 'Apple Color Emoji', 'Segoe UI Emoji'",
+      '--font-mono':
+        "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace",
+      '--text-sm': '0.875rem',
+      '--text-base': '1rem',
+      '--text-lg': '1.125rem',
+      '--text-xl': '1.25rem',
+    },
+  },
+]
+
+export default DEFAULT_THEMES

--- a/@guidogerb/css/src/useTheme.js
+++ b/@guidogerb/css/src/useTheme.js
@@ -1,0 +1,8 @@
+import { useContext } from 'react'
+import { ThemeContext } from './ThemeContext.js'
+
+export function useTheme() {
+  return useContext(ThemeContext)
+}
+
+export default useTheme

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -163,6 +163,12 @@ importers:
 
   '@guidogerb/css':
     devDependencies:
+      react:
+        specifier: ^19.1.1
+        version: 19.1.1
+      react-dom:
+        specifier: ^19.1.1
+        version: 19.1.1(react@19.1.1)
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(jsdom@27.0.0(postcss@8.5.6))


### PR DESCRIPTION
## Summary
- add a ThemeProvider that normalizes available themes, hydrates persisted selections, and applies tokens to the document
- expose a ThemeSelect control, persistence helpers, and default theme definitions for header integrations
- document usage and cover the provider and selector flows with tests

## Testing
- pnpm --filter @guidogerb/css test

------
https://chatgpt.com/codex/tasks/task_e_68cd25f6cae88324a03ce4b4b24a2021