### PR TITLE
Document util helpers and improve inline docs

### DIFF
--- a/@guidogerb/util/README.md
+++ b/@guidogerb/util/README.md
@@ -1,0 +1,116 @@
+# `@guidogerb/util`
+
+Utility helpers shared across the Guidogerb front-end projects.  The package is intentionally framework-light but
+includes a handful of helpers that assume a browser and/or React environment.
+
+## Installation
+
+The utilities are published as a workspace package.  Within the monorepo they can be imported directly:
+
+```js
+import { joinClassNames, stringToId } from '@guidogerb/util'
+```
+
+## API Reference
+
+### Array and object helpers
+
+#### `arrayMatchRecursive({ object, arrayField, isMatchFunc })`
+Walks a tree structure where each node exposes an array of children via `arrayField`.  Returns `true` when the predicate
+matches on the node itself or any descendant.
+
+```js
+const hasSelected = arrayMatchRecursive({
+  object: tree,
+  arrayField: 'children',
+  isMatchFunc: (node) => node.selected,
+})
+```
+
+#### `chainSorters(sorters, ...params)`
+Combines multiple comparator functions so they are evaluated in sequence.  Stops when one comparator returns a non-zero
+result and is therefore ideal for multi-level sorting.
+
+```js
+const sorter = chainSorters([
+  (a, b) => a.last.localeCompare(b.last),
+  (a, b) => a.first.localeCompare(b.first),
+  (a, b) => a.age - b.age,
+])
+items.sort(sorter)
+```
+
+#### `notNull(value, message)`
+Throws an error when the provided value is `null`/`undefined` and returns a narrowed `NonNullable<T>` type otherwise.
+Useful for runtime assertions that also improve TypeScript type inference.
+
+#### `notNullArray(array, message)`
+Ensures the array itself and every element inside is defined.  Throws with the supplied message when any value is missing
+and returns an array typed as `NonNullable<T>[]` when validation succeeds.
+
+#### `notNullMap(value)`
+A convenience wrapper around `notNull` that throws a generic error message.  Handy for chaining with `map`:
+
+```js
+values.filter(Boolean).map(notNullMap)
+```
+
+#### `valueAtPath({ object, path })`
+Reads a nested value from an object using a dot-delimited path string and returns `undefined` when any part of the path is
+missing.
+
+#### `setValueAtPath({ object, path, value })`
+Clones the object along the specified path and assigns the new value while leaving other branches untouched—perfect for
+immutably updating React state.
+
+### DOM helpers
+
+#### `getFocusableElements(element)`
+Returns the focusable descendants of a container element, filtered to remove disabled controls.  Useful when implementing
+focus traps for dialogs or menus.
+
+#### `htmlDecode(input)`
+Uses the browser’s HTML parser to decode entity references like `&amp;` into their literal characters.
+
+#### `rectContainsPoint(rect, point)`
+Determines whether the provided `x`/`y` point lies within the inclusive bounds of the supplied `DOMRect`.
+
+### Events and React
+
+#### `handleEvent(handler)`
+Wraps an event handler so that `preventDefault`, `stopPropagation`, and (for React) `stopImmediatePropagation` are called
+before the handler executes.  Ideal for button click handlers inside components with other nested event listeners.
+
+#### `handleKeyPress(code, handler)`
+Creates a React keyboard handler that calls `handler` only when `event.code` matches the supplied code (such as `'Enter'`
+or `'Escape'`).
+
+#### `useOnKeyUp(targetKey, handler, stopPropagation?)`
+React hook that memoises a key-up handler, invoking it when the specified key is released.  Optionally prevents default
+behaviour and event bubbling when `stopPropagation` is truthy.
+
+### String and formatting helpers
+
+#### `joinClassNames(...values)`
+Accepts any combination of class name strings, arrays and falsy values.  Flattens and trims the input and returns a single
+space-delimited class name string.
+
+#### `stringToId(input)`
+Normalises arbitrary text into a lowercase, hyphenated string that is safe to use as an HTML id attribute.
+
+#### `toSafeString(value)`
+Converts values into strings while treating `null`/`undefined` as an empty string and leaving `0` intact—handy for
+uncontrolled form inputs.
+
+#### `trailingS(value)`
+Returns `'s'` when `value` is greater than or equal to two; returns an empty string otherwise.  Combine with template
+strings to pluralise labels.
+
+### Environment notes
+
+Some utilities expect certain runtime features:
+
+- **React-specific helpers** – `handleEvent`, `handleKeyPress`, and `useOnKeyUp` rely on React’s synthetic event types. Use
+  native event helpers when working outside React.
+- **Browser-only helpers** – `arrayMatchRecursive` and the DOM utilities depend on browser globals (`window`,
+  `document`, `DOMParser`).  Guard these calls when rendering on the server.

--- a/@guidogerb/util/arrayMatchRecursive.js
+++ b/@guidogerb/util/arrayMatchRecursive.js
@@ -1,19 +1,36 @@
 import { identity } from 'lodash'
 
 /**
- * Tests if an object or any of its children pass a custom match test.
- * @param {object} param
- * @param {Record<string, any>} param.object the object in which to search for a match AND check its children if they exist
- * @param {string} param.arrayField which field is the "children" array
- * @param {(arrayItem: any) => boolean} param.isMatchFunc the object and each child will be passed to this function to test for truthiness
- * @returns {boolean} true if the object or any of its "children" pass the isMatchFunc test
+ * Recursively searches a tree-like structure and returns whether any node matches the provided predicate.
+ *
+ * The function expects each node in the tree to expose its children through the same field name
+ * (for example `children` or `items`).  A typical call therefore looks like:
+ *
+ * ```js
+ * const hasSelectedNode = arrayMatchRecursive({
+ *   object: rootNode,
+ *   arrayField: 'children',
+ *   isMatchFunc: (node) => node.selected,
+ * })
+ * ```
+ *
+ * @param {object} params
+ * @param {Record<string, any> | null | undefined} params.object Node to evaluate.
+ * @param {string} params.arrayField Name of the field that stores child nodes.
+ * @param {(arrayItem: any) => boolean} params.isMatchFunc Predicate that determines a match.
+ * @returns {boolean} True when the node itself or any descendant satisfies {@link params.isMatchFunc}.
  */
 export function arrayMatchRecursive({ object, arrayField, isMatchFunc }) {
-  return !!object?.[arrayField]?.filter(identity)?.some(
-    /**
-     * @param {any} arrayItem
-     * @returns {boolean}
-     */
-    (arrayItem) => isMatchFunc(arrayItem) || arrayMatchRecursive(arrayItem),
+  if (!object) {
+    return false
+  }
+
+  if (isMatchFunc(object)) {
+    return true
+  }
+
+  const children = Array.isArray(object[arrayField]) ? object[arrayField].filter(identity) : []
+  return children.some((arrayItem) =>
+    arrayMatchRecursive({ object: arrayItem, arrayField, isMatchFunc }),
   )
 }

--- a/@guidogerb/util/chainSorters.js
+++ b/@guidogerb/util/chainSorters.js
@@ -1,8 +1,21 @@
 /**
- * Oftentimes you want to sort by multiple levels so that if the first level of sorting results in an equals result then compare the next level
- * @param {((a: any, b: any, ...rest: any[]) => number)[]} sorters sorter funcs in sort order; ie (a, b) => a - b
- * @param {any} [sorterParams] can add extra parameters to pass in to each sorter; these are spread in to the sorter
- * @returns {(a: any, b: any) => number} func that takes a & b parameters and if the comparison result is zero then calls the next sorter in the array
+ * Creates a comparison function that tries several comparator callbacks in sequence until one returns a non-zero result.
+ *
+ * This is helpful when sorting complex objects by more than one criterion.  For example:
+ *
+ * ```js
+ * const peopleSorter = chainSorters([
+ *   (a, b) => a.lastName.localeCompare(b.lastName),
+ *   (a, b) => a.firstName.localeCompare(b.firstName),
+ *   (a, b) => a.age - b.age,
+ * ])
+ *
+ * people.sort(peopleSorter)
+ * ```
+ *
+ * @param {((a: any, b: any, ...rest: any[]) => number)[]} sorters Comparator callbacks ordered by priority.
+ * @param {any[]} sorterParams Additional parameters spread into every sorter invocation (useful for dependency injection).
+ * @returns {(a: any, b: any) => number} Comparison function suitable for `Array.prototype.sort`.
  */
 export function chainSorters(sorters, ...sorterParams) {
   return (

--- a/@guidogerb/util/getFocusableElements.js
+++ b/@guidogerb/util/getFocusableElements.js
@@ -1,8 +1,11 @@
 /**
- * Based on the list from https://api.jqueryui.com/tabbable-selector/
- * Used to get a list of focusable elements within a modal component
- * @param {HTMLDialogElement} element
- * @returns {HTMLElement[]}
+ * Returns a list of elements within the provided container that can receive focus via keyboard navigation.
+ *
+ * The selector is adapted from the jQuery UI tabbable selector list and trimmed to match the needs of the component library.
+ * Disabled elements are explicitly filtered out because they are technically tabbable but should be skipped by focus traps.
+ *
+ * @param {HTMLElement} element Root element whose descendants should be evaluated for focusability.
+ * @returns {HTMLElement[]} A flat array of focusable descendants in DOM order.
  */
 export function getFocusableElements(element) {
   // @ts-expect-error Element vs HTMLElement... why?!?!?!

--- a/@guidogerb/util/handleEvent.js
+++ b/@guidogerb/util/handleEvent.js
@@ -1,9 +1,13 @@
 /**
- * A function used as a callback often needs to the triggering event
- * from triggering other events. Wrapping the function in this handleEvent function
- * automatically stops the event propagation. ie handleEvent(() => { ... do something ... })
- * @param {import('react').MouseEventHandler<HTMLButtonElement>} func The function to run
- * @returns {import('react').MouseEventHandler<HTMLButtonElement>}
+ * Wraps an event handler and automatically prevents default behaviour and event bubbling before executing the callback.
+ *
+ * This helper is primarily used around button click handlers to ensure that the action does not trigger parent listeners or
+ * submit forms.  The returned function preserves React's synthetic event signature so it can be passed directly to
+ * JSX props.
+ *
+ * @template {Element} ElementT
+ * @param {import('react').MouseEventHandler<ElementT>} func The handler to execute once the event has been neutralised.
+ * @returns {import('react').MouseEventHandler<ElementT>} The wrapped handler that can be attached to event listeners.
  */
 export function handleEvent(func) {
   return (e) => {

--- a/@guidogerb/util/handleKeyPress.js
+++ b/@guidogerb/util/handleKeyPress.js
@@ -4,10 +4,14 @@
  */
 
 /**
+ * Creates a keyboard event handler that delegates to `handler` only when the browser reports the matching `KeyboardEvent.code`.
+ *
+ * Useful when wiring up onKeyDown/onKeyUp listeners without having to repeat guard clauses in component code.
+ *
  * @template KeyboardEventHandlerT
- * @param {string} code
- * @param {import('react').EventHandler<any>} handler
- * @returns {import('react').KeyboardEventHandler<KeyboardEventHandlerT>}
+ * @param {string} code Keyboard event `code` to listen for (for example `'Enter'` or `'Escape'`).
+ * @param {import('react').EventHandler<any>} handler Callback executed when the code matches.
+ * @returns {import('react').KeyboardEventHandler<KeyboardEventHandlerT>} React-compatible handler enforcing the guard.
  */
 export function handleKeyPress(code, handler) {
   return (e) => e.code === code && handler(e)

--- a/@guidogerb/util/htmlDecode.js
+++ b/@guidogerb/util/htmlDecode.js
@@ -1,7 +1,9 @@
 // https://stackoverflow.com/a/34064434/1478933
 /**
- * @param {string} input
- * @returns {string}
+ * Decodes HTML entities (such as `&amp;` or `&#x27;`) into their literal characters using the browser's HTML parser.
+ *
+ * @param {string} input Markup or text that may contain encoded entities.
+ * @returns {string} Decoded string value (or an empty string when parsing fails).
  */
 export function htmlDecode(input) {
   const doc = new DOMParser().parseFromString(input, 'text/html')

--- a/@guidogerb/util/joinClassNames.js
+++ b/@guidogerb/util/joinClassNames.js
@@ -1,9 +1,14 @@
 import { castArray, identity, trim } from 'lodash'
 
 /**
- * pass in comma separated list of class name strings to be trimmed, filtered, and joined together with a space
- * @param {(string | boolean | any[] | null | undefined)[]} classNames really can be anything, but should be string if truey
- * @returns {string}
+ * Accepts any combination of strings, arrays, booleans, nulls or undefined values and joins the truthy class names into a
+ * single space-delimited string.
+ *
+ * The utility is deliberately forgiving – anything that is not a string simply passes through the filtering stage and is
+ * ignored.  Arrays are flattened recursively so nested lists of classes are supported.
+ *
+ * @param {(string | boolean | any[] | null | undefined)[]} classNames Values representing CSS class names.
+ * @returns {string} A string safe to pass to React's `className` prop.
  */
 export function joinClassNames(...classNames) {
   return (

--- a/@guidogerb/util/notNull.js
+++ b/@guidogerb/util/notNull.js
@@ -1,10 +1,13 @@
 /**
- * https://docs.joshuatz.com/cheatsheets/js/jsdoc/#non-null-assertion-in-jsdoc
- * Exclude in JSDoc removes a type from another type. The returned `T` no longer has `null` nor `undefined` in its type
+ * Runtime assertion that a value is neither `null` nor `undefined`.
+ *
+ * In addition to throwing a descriptive error when the value is missing, the function narrows the TypeScript type to
+ * `NonNullable<T>` for subsequent code paths.
+ *
  * @template T
- * @param {T} value
- * @param {string} errorMessage
- * @returns {NonNullable<T>}
+ * @param {T} value Value that should be validated.
+ * @param {string} errorMessage Message included in the thrown error when validation fails.
+ * @returns {NonNullable<T>} The same value but with a narrowed type contract.
  */
 export function notNull(value, errorMessage) {
   if (value === null || value === undefined) {

--- a/@guidogerb/util/notNullArray.js
+++ b/@guidogerb/util/notNullArray.js
@@ -1,12 +1,15 @@
 import { notNull } from './notNull'
 
 /**
- * Makes sure all elements in an array are neither null nor undefined (for type safety)
- * You should be pretty confident that things can't be null or undefined before calling this
+ * Asserts that every item in an array is defined and returns a narrowed array type.
+ *
+ * Because the function throws on the first `null` or `undefined` value, it should only be used when missing entries are
+ * truly exceptional and should halt execution.
+ *
  * @template T
- * @param {T[] | null | undefined} array
- * @param {string} errorMessage
- * @returns {NonNullable<T>[]}
+ * @param {T[] | null | undefined} array Array to validate (or `null`/`undefined` if optional).
+ * @param {string} errorMessage Message included in the thrown error when any element is missing.
+ * @returns {NonNullable<T>[]} Array where TypeScript understands that `null` and `undefined` have been removed.
  */
 export function notNullArray(array, errorMessage) {
   if (array === null || array === undefined) {

--- a/@guidogerb/util/notNullMap.js
+++ b/@guidogerb/util/notNullMap.js
@@ -1,13 +1,11 @@
 /**
- * https://docs.joshuatz.com/cheatsheets/js/jsdoc/#non-null-assertion-in-jsdoc
- * Exclude in JSDoc removes a type from another type. The returned `T` no longer has `null` nor `undefined` in its type
+ * Convenience wrapper for {@link notNull} that throws a generic message and is therefore easy to pass to `map`.
  *
- * This function is not as nice as its cousin notNull() because it does not require a message
- * This function is nice to pass to a map function where you know FOR SURE that all the value are not null/undefined.
- * ie myValuesArray.filter(identity).map(notNullMap) so that the type system now knows that all the values are not null
+ * Usage pattern: `values.filter(Boolean).map(notNullMap)`.
+ *
  * @template T
- * @param {T} value
- * @returns {NonNullable<T>}
+ * @param {T} value Value that must be defined.
+ * @returns {NonNullable<T>} The same value with a narrowed type signature.
  */
 export function notNullMap(value) {
   if (value === null || value === undefined) {

--- a/@guidogerb/util/rectContainsPoint.js
+++ b/@guidogerb/util/rectContainsPoint.js
@@ -1,8 +1,9 @@
 /**
- * determines if a point is inclusively within a rectangle. helpful for checking if a click was on an element.
- * @param {DOMRect} rect ({top, bottom, left, right}) defines an area
- * @param {{ x: number, y: number }} point ({x, y}) defines a point
- * @returns {boolean}
+ * Determines whether a point lies within the inclusive bounds of a `DOMRect`.
+ *
+ * @param {DOMRect} rect Rectangle whose boundaries will be checked.
+ * @param {{ x: number, y: number }} point Coordinates to test, usually `MouseEvent` positions.
+ * @returns {boolean} True if the point is inside or on the edge of the rectangle.
  */
 export function rectContainsPoint(rect, point) {
   return (

--- a/@guidogerb/util/state/valueAtPath.js
+++ b/@guidogerb/util/state/valueAtPath.js
@@ -1,12 +1,17 @@
 import { split } from 'lodash'
 
 /**
+ * Safely reads a nested property from an object using a dot-delimited path string.
+ *
+ * Missing intermediate objects simply short-circuit to `undefined` instead of throwing.  The return type is generic so it
+ * can be asserted when used in TypeScript-aware codebases.
+ *
  * @template ObjectT
  * @template ValueT
  * @param {object} param
- * @param {ObjectT | null} param.object
- * @param {string} param.path
- * @returns {ValueT}
+ * @param {ObjectT | null} param.object Object to traverse.
+ * @param {string} param.path Dot-delimited path string (e.g. `'a.b.c'`).
+ * @returns {ValueT} Value located at the path or `undefined` if any segment is missing.
  */
 export function valueAtPath({ object, path }) {
   // eslint-disable-next-line jsdoc/no-undefined-types

--- a/@guidogerb/util/stringToId.js
+++ b/@guidogerb/util/stringToId.js
@@ -1,7 +1,11 @@
 /**
- * Convert an input string such as a title to a valid html id
- * @param {string} inputString The string to convert to an html id string
- * @returns {string}
+ * Converts human-readable text into a lowercase, hyphenated string that is safe to use as an HTML id attribute.
+ *
+ * The function strips non-alphanumeric characters (except for hyphens) and collapses whitespace into single hyphen
+ * separators.
+ *
+ * @param {string} inputString The string to convert into an identifier.
+ * @returns {string} Sanitised id that can be used in the DOM.
  */
 export function stringToId(inputString) {
   let retVal

--- a/@guidogerb/util/toSafeString.js
+++ b/@guidogerb/util/toSafeString.js
@@ -1,6 +1,11 @@
 /**
- * @param {string | number | null | undefined} value
- * @returns {string}
+ * Safely converts a value into a string while treating `null`, `undefined` and empty values as an empty string.
+ *
+ * Particularly useful when binding values to uncontrolled form elements where `null` is not an acceptable value but `0`
+ * should be preserved.
+ *
+ * @param {string | number | null | undefined} value Value to convert.
+ * @returns {string} String representation or an empty string for absent values.
  */
 export function toSafeString(value) {
   return !value && value !== 0 ? '' : `${value}`

--- a/@guidogerb/util/trailingS.js
+++ b/@guidogerb/util/trailingS.js
@@ -1,7 +1,12 @@
 /**
- * returns an 's' if the number is plural
- * @param {number} value
- * @returns {string}
+ * Returns an `'s'` suffix when the provided count is plural (two or more) and an empty string otherwise.
+ *
+ * ```js
+ * `item${trailingS(count)}`
+ * ```
+ *
+ * @param {number} value Quantity being displayed to the user.
+ * @returns {string} `'s'` for plural values, otherwise an empty string.
  */
 export function trailingS(value) {
   return value >= 2 ? 's' : ''

--- a/@guidogerb/util/useOnKeyUp.js
+++ b/@guidogerb/util/useOnKeyUp.js
@@ -1,11 +1,16 @@
 import React, { useCallback } from 'react'
 
 /**
+ * React hook that returns a memoised key-up handler which fires only for the specified key.
+ *
+ * When `stopPropagation` is true the handler also prevents further propagation and default browser behaviour, making it
+ * useful for custom keyboard shortcuts inside components such as dialogs.
+ *
  * @template KeyboardEventElementT
- * @param {string} targetKey which key to watch for (ie 'Enter') https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_key_values
- * @param {import('react').KeyboardEventHandler<KeyboardEventElementT>} func the function to call when the given key is pressed
- * @param {boolean} [stopPropagation]
- * @returns {(event: React.KeyboardEvent<KeyboardEventElementT>) => boolean} function that checks for the keypress and fires function when pressed
+ * @param {string} targetKey Key to watch for (for example `'Enter'`).  See MDN's KeyboardEvent key values reference.
+ * @param {import('react').KeyboardEventHandler<KeyboardEventElementT>} func Function invoked when the key is pressed.
+ * @param {boolean} [stopPropagation] Whether to stop propagation and prevent default behaviour when the key matches.
+ * @returns {(event: React.KeyboardEvent<KeyboardEventElementT>) => boolean} Memoised handler returning whether the key matched.
  */
 export function useOnKeyUp(targetKey, func, stopPropagation) {
   return useCallback(


### PR DESCRIPTION
## Summary
- add a README for `@guidogerb/util` covering every exported helper
- expand inline JSDoc across the utility modules for clarity and usage examples
- tidy recursive matcher implementation so it evaluates descendants correctly

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cd724702fc83248e60807ac4f4e728