### PR TITLE
Modularize publishing sections and add component smoke tests

### DIFF
--- a/websites/guidogerbpublishing.com/src/App.jsx
+++ b/websites/guidogerbpublishing.com/src/App.jsx
@@ -1,11 +1,17 @@
 import { useCallback, useEffect, useState } from 'react'
-import Protected from '@guidogerb/components-pages-protected'
 import { Footer } from '@guidogerb/footer'
 import { Header, HeaderContextProvider } from '@guidogerb/header'
 import './App.css'
 import headerSettings from './headerSettings.js'
 import footerSettings from './footerSettings.js'
-import Welcome from './website-components/welcome-page/index.jsx'
+import {
+  DistributionSection,
+  HeroSection,
+  NewsletterSection,
+  PartnerPortalSection,
+  PlatformSection,
+  ResourcesSection,
+} from './website-components/sections/index.js'
 
 const SECTION_MAP = {
   '/': 'top',
@@ -108,166 +114,12 @@ function App() {
         <Header activePath={activePath} onNavigate={handleNavigate} />
 
         <main className="app-main">
-          <section className="hero" id="solutions">
-            <p className="eyebrow">Publishing operations for modern catalogs</p>
-            <h1>
-              GuidoGerb Publishing brings manuscripts to market with full-service production and
-              rights management.
-            </h1>
-            <p className="lede">
-              From editorial strategy to digital distribution, we partner with authors, ensembles,
-              and arts organizations to deliver releases across print, audio, and interactive
-              channels.
-            </p>
-            <dl className="hero-highlights" aria-label="Publishing impact highlights">
-              <div>
-                <dt>600+</dt>
-                <dd>active titles across scores, recordings, and digital editions</dd>
-              </div>
-              <div>
-                <dt>40</dt>
-                <dd>new releases shepherded each season with dedicated launch plans</dd>
-              </div>
-              <div>
-                <dt>85%</dt>
-                <dd>catalog revenue delivered through direct-to-audience storefronts</dd>
-              </div>
-            </dl>
-          </section>
-
-          <section className="content-grid" id="platform">
-            <article>
-              <h2>Integrated publishing console</h2>
-              <p>
-                Manage your entire catalog from manuscript intake to multi-format delivery. Our
-                console keeps metadata, assets, and rights aligned so every release stays
-                market-ready.
-              </p>
-              <ul className="feature-list">
-                <li>Rights tracking for print, sync, and streaming agreements</li>
-                <li>Automated ISRC, ISBN, and UPC assignment with validation rules</li>
-                <li>Version history for scores, parts, and marketing collateral</li>
-              </ul>
-            </article>
-            <article>
-              <h2>Collaborative editorial workflows</h2>
-              <p>
-                Bring editors, arrangers, and composers into a shared workspace. Built-in review
-                stages keep everyone aligned on deadlines and quality gates.
-              </p>
-              <ul className="feature-list">
-                <li>Comment threads with score and manuscript annotations</li>
-                <li>Approval checkpoints with automated reminders</li>
-                <li>Asset lockers for stems, engravings, and print-ready files</li>
-              </ul>
-            </article>
-          </section>
-
-          <section className="content-grid" id="distribution">
-            <article>
-              <h2>Distribution channels</h2>
-              <p>
-                Launch simultaneously across streaming, retail, and licensing partners. We handle
-                ingestion and compliance so your team can stay focused on building the catalog.
-              </p>
-              <ul className="feature-list">
-                <li>Direct delivery to Apple Music, Spotify, and classical-focused DSPs</li>
-                <li>Global print-on-demand and warehouse fulfillment management</li>
-                <li>Synchronization licensing pipeline with broadcast ready assets</li>
-              </ul>
-            </article>
-            <article>
-              <h2>Direct-to-audience storefronts</h2>
-              <p>
-                Pair traditional channels with branded storefronts for ensembles, artists, and
-                educators. Flexible bundles and subscription models help you grow recurring revenue.
-              </p>
-              <ul className="feature-list">
-                <li>Customizable microsites with secure score and media delivery</li>
-                <li>Dynamic pricing tiers for studios, institutions, and touring groups</li>
-                <li>Customer analytics with cohort retention and royalty forecasting</li>
-              </ul>
-            </article>
-          </section>
-
-          <section className="content-grid" id="resources">
-            <article>
-              <h2>Author onboarding</h2>
-              <p>
-                Provide contributors with a clear path from first draft to launch. Templates,
-                checklists, and personal consultations ensure every project is ready for
-                distribution.
-              </p>
-              <ul className="feature-list">
-                <li>Submission portal with formatting guidelines and asset requirements</li>
-                <li>Release readiness scorecards and marketing asset checklists</li>
-                <li>Quarterly planning sessions with our editorial and licensing leads</li>
-              </ul>
-            </article>
-            <article>
-              <h2>Marketing toolkit</h2>
-              <p>
-                Keep campaigns consistent with modular launch kits tailored to recordings,
-                educational content, and performance rights packages.
-              </p>
-              <ul className="feature-list">
-                <li>Pre-built email, social, and press release templates</li>
-                <li>Digital ad creative sized for arts presenters and music retailers</li>
-                <li>Audience journey maps to align nurture and paid campaigns</li>
-              </ul>
-            </article>
-            <article>
-              <h2>Compliance resources</h2>
-              <p>
-                Stay ahead of regional reporting and royalty requirements. Our resource library
-                keeps your team current on mechanical, performance, and educational licensing rules.
-              </p>
-              <ul className="feature-list">
-                <li>Regional royalty calendars and automated filing reminders</li>
-                <li>Template agreements for composers, arrangers, and narrators</li>
-                <li>Security checklist covering data residency and archival policies</li>
-              </ul>
-            </article>
-          </section>
-
-          <section className="newsletter" id="newsletter">
-            <div>
-              <h2>Quarterly publishing brief</h2>
-              <p>
-                Join our newsletter for catalog performance insights, partner spotlights, and
-                submission deadlines. We highlight actionable trends for catalogs serving arts
-                organizations and creative entrepreneurs.
-              </p>
-            </div>
-            <form
-              className="newsletter-form"
-              aria-label="Newsletter sign up"
-              onSubmit={(event) => event.preventDefault()}
-            >
-              <label htmlFor="newsletter-email" className="visually-hidden">
-                Email address
-              </label>
-              <input
-                id="newsletter-email"
-                type="email"
-                name="email"
-                placeholder="you@example.com"
-                autoComplete="email"
-              />
-              <button type="submit">Subscribe</button>
-            </form>
-          </section>
-
-          <section className="protected" id="partner-portal">
-            <h2>Partner operations portal</h2>
-            <p className="protected-copy">
-              Signed-in partners can review royalty dashboards, download assets, and coordinate
-              release plans with our production team.
-            </p>
-            <Protected logoutUri={import.meta.env.VITE_LOGOUT_URI}>
-              <Welcome />
-            </Protected>
-          </section>
+          <HeroSection />
+          <PlatformSection />
+          <DistributionSection />
+          <ResourcesSection />
+          <NewsletterSection />
+          <PartnerPortalSection logoutUri={import.meta.env.VITE_LOGOUT_URI} />
         </main>
 
         <Footer {...footerSettings} onNavigate={handleNavigate} id="contact">

--- a/websites/guidogerbpublishing.com/src/tasks.md
+++ b/websites/guidogerbpublishing.com/src/tasks.md
@@ -3,5 +3,5 @@
 | name                               | createdDate | lastUpdatedDate | completedDate | status   | description                                                                                            |
 | ---------------------------------- | ----------- | --------------- | ------------- | -------- | ------------------------------------------------------------------------------------------------------ |
 | Document marketing shell structure | 2025-09-19  | 2025-09-19      | 2025-09-19    | complete | README now calls out the entry point, navigation settings, and partner welcome component.              |
-| Modularize App sections            | 2025-09-19  | 2025-09-19      | -             | todo     | Break `App.jsx` into section components (Platform, Distribution, Resources) for readability and reuse. |
+| Modularize App sections            | 2025-09-19  | 2025-09-21      | 2025-09-21    | complete | Break `App.jsx` into section components (Platform, Distribution, Resources) for readability and reuse. |
 | Connect to CMS-driven content      | 2025-09-19  | 2025-09-19      | -             | todo     | Replace hard-coded copy with data fetched from the publishing CMS once endpoints are available.        |

--- a/websites/guidogerbpublishing.com/src/website-components/sections/DistributionSection.jsx
+++ b/websites/guidogerbpublishing.com/src/website-components/sections/DistributionSection.jsx
@@ -1,0 +1,30 @@
+export function DistributionSection() {
+  return (
+    <section className="content-grid" id="distribution">
+      <article>
+        <h2>Distribution channels</h2>
+        <p>
+          Launch simultaneously across streaming, retail, and licensing partners. We handle
+          ingestion and compliance so your team can stay focused on building the catalog.
+        </p>
+        <ul className="feature-list">
+          <li>Direct delivery to Apple Music, Spotify, and classical-focused DSPs</li>
+          <li>Global print-on-demand and warehouse fulfillment management</li>
+          <li>Synchronization licensing pipeline with broadcast ready assets</li>
+        </ul>
+      </article>
+      <article>
+        <h2>Direct-to-audience storefronts</h2>
+        <p>
+          Pair traditional channels with branded storefronts for ensembles, artists, and educators.
+          Flexible bundles and subscription models help you grow recurring revenue.
+        </p>
+        <ul className="feature-list">
+          <li>Customizable microsites with secure score and media delivery</li>
+          <li>Dynamic pricing tiers for studios, institutions, and touring groups</li>
+          <li>Customer analytics with cohort retention and royalty forecasting</li>
+        </ul>
+      </article>
+    </section>
+  )
+}

--- a/websites/guidogerbpublishing.com/src/website-components/sections/HeroSection.jsx
+++ b/websites/guidogerbpublishing.com/src/website-components/sections/HeroSection.jsx
@@ -1,0 +1,29 @@
+export function HeroSection() {
+  return (
+    <section className="hero" id="solutions">
+      <p className="eyebrow">Publishing operations for modern catalogs</p>
+      <h1>
+        GuidoGerb Publishing brings manuscripts to market with full-service production and rights
+        management.
+      </h1>
+      <p className="lede">
+        From editorial strategy to digital distribution, we partner with authors, ensembles, and
+        arts organizations to deliver releases across print, audio, and interactive channels.
+      </p>
+      <dl className="hero-highlights" aria-label="Publishing impact highlights">
+        <div>
+          <dt>600+</dt>
+          <dd>active titles across scores, recordings, and digital editions</dd>
+        </div>
+        <div>
+          <dt>40</dt>
+          <dd>new releases shepherded each season with dedicated launch plans</dd>
+        </div>
+        <div>
+          <dt>85%</dt>
+          <dd>catalog revenue delivered through direct-to-audience storefronts</dd>
+        </div>
+      </dl>
+    </section>
+  )
+}

--- a/websites/guidogerbpublishing.com/src/website-components/sections/NewsletterSection.jsx
+++ b/websites/guidogerbpublishing.com/src/website-components/sections/NewsletterSection.jsx
@@ -1,0 +1,31 @@
+export function NewsletterSection() {
+  return (
+    <section className="newsletter" id="newsletter">
+      <div>
+        <h2>Quarterly publishing brief</h2>
+        <p>
+          Join our newsletter for catalog performance insights, partner spotlights, and submission
+          deadlines. We highlight actionable trends for catalogs serving arts organizations and
+          creative entrepreneurs.
+        </p>
+      </div>
+      <form
+        className="newsletter-form"
+        aria-label="Newsletter sign up"
+        onSubmit={(event) => event.preventDefault()}
+      >
+        <label htmlFor="newsletter-email" className="visually-hidden">
+          Email address
+        </label>
+        <input
+          id="newsletter-email"
+          type="email"
+          name="email"
+          placeholder="you@example.com"
+          autoComplete="email"
+        />
+        <button type="submit">Subscribe</button>
+      </form>
+    </section>
+  )
+}

--- a/websites/guidogerbpublishing.com/src/website-components/sections/PartnerPortalSection.jsx
+++ b/websites/guidogerbpublishing.com/src/website-components/sections/PartnerPortalSection.jsx
@@ -1,0 +1,17 @@
+import Protected from '@guidogerb/components-pages-protected'
+import Welcome from '../welcome-page/index.jsx'
+
+export function PartnerPortalSection({ logoutUri }) {
+  return (
+    <section className="protected" id="partner-portal">
+      <h2>Partner operations portal</h2>
+      <p className="protected-copy">
+        Signed-in partners can review royalty dashboards, download assets, and coordinate release
+        plans with our production team.
+      </p>
+      <Protected logoutUri={logoutUri}>
+        <Welcome />
+      </Protected>
+    </section>
+  )
+}

--- a/websites/guidogerbpublishing.com/src/website-components/sections/PlatformSection.jsx
+++ b/websites/guidogerbpublishing.com/src/website-components/sections/PlatformSection.jsx
@@ -1,0 +1,30 @@
+export function PlatformSection() {
+  return (
+    <section className="content-grid" id="platform">
+      <article>
+        <h2>Integrated publishing console</h2>
+        <p>
+          Manage your entire catalog from manuscript intake to multi-format delivery. Our console
+          keeps metadata, assets, and rights aligned so every release stays market-ready.
+        </p>
+        <ul className="feature-list">
+          <li>Rights tracking for print, sync, and streaming agreements</li>
+          <li>Automated ISRC, ISBN, and UPC assignment with validation rules</li>
+          <li>Version history for scores, parts, and marketing collateral</li>
+        </ul>
+      </article>
+      <article>
+        <h2>Collaborative editorial workflows</h2>
+        <p>
+          Bring editors, arrangers, and composers into a shared workspace. Built-in review stages
+          keep everyone aligned on deadlines and quality gates.
+        </p>
+        <ul className="feature-list">
+          <li>Comment threads with score and manuscript annotations</li>
+          <li>Approval checkpoints with automated reminders</li>
+          <li>Asset lockers for stems, engravings, and print-ready files</li>
+        </ul>
+      </article>
+    </section>
+  )
+}

--- a/websites/guidogerbpublishing.com/src/website-components/sections/ResourcesSection.jsx
+++ b/websites/guidogerbpublishing.com/src/website-components/sections/ResourcesSection.jsx
@@ -1,0 +1,42 @@
+export function ResourcesSection() {
+  return (
+    <section className="content-grid" id="resources">
+      <article>
+        <h2>Author onboarding</h2>
+        <p>
+          Provide contributors with a clear path from first draft to launch. Templates, checklists,
+          and personal consultations ensure every project is ready for distribution.
+        </p>
+        <ul className="feature-list">
+          <li>Submission portal with formatting guidelines and asset requirements</li>
+          <li>Release readiness scorecards and marketing asset checklists</li>
+          <li>Quarterly planning sessions with our editorial and licensing leads</li>
+        </ul>
+      </article>
+      <article>
+        <h2>Marketing toolkit</h2>
+        <p>
+          Keep campaigns consistent with modular launch kits tailored to recordings, educational
+          content, and performance rights packages.
+        </p>
+        <ul className="feature-list">
+          <li>Pre-built email, social, and press release templates</li>
+          <li>Digital ad creative sized for arts presenters and music retailers</li>
+          <li>Audience journey maps to align nurture and paid campaigns</li>
+        </ul>
+      </article>
+      <article>
+        <h2>Compliance resources</h2>
+        <p>
+          Stay ahead of regional reporting and royalty requirements. Our resource library keeps your
+          team current on mechanical, performance, and educational licensing rules.
+        </p>
+        <ul className="feature-list">
+          <li>Regional royalty calendars and automated filing reminders</li>
+          <li>Template agreements for composers, arrangers, and narrators</li>
+          <li>Security checklist covering data residency and archival policies</li>
+        </ul>
+      </article>
+    </section>
+  )
+}

--- a/websites/guidogerbpublishing.com/src/website-components/sections/__tests__/Sections.test.jsx
+++ b/websites/guidogerbpublishing.com/src/website-components/sections/__tests__/Sections.test.jsx
@@ -1,0 +1,90 @@
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockProtected } = vi.hoisted(() => ({
+  mockProtected: vi.fn(),
+}))
+
+vi.mock('@guidogerb/components-pages-protected', () => ({
+  __esModule: true,
+  default: ({ children, ...props }) => {
+    mockProtected(props)
+    return <div data-testid="protected-shell">{children}</div>
+  },
+}))
+
+vi.mock('../../welcome-page/index.jsx', () => ({
+  __esModule: true,
+  default: () => <div data-testid="welcome-component">Welcome module</div>,
+}))
+
+import {
+  DistributionSection,
+  HeroSection,
+  NewsletterSection,
+  PartnerPortalSection,
+  PlatformSection,
+  ResourcesSection,
+} from '../index.js'
+
+describe('marketing sections', () => {
+  beforeEach(() => {
+    mockProtected.mockClear()
+  })
+
+  it('renders the hero content without crashing', () => {
+    render(<HeroSection />)
+
+    expect(
+      screen.getByRole('heading', {
+        level: 1,
+        name: /GuidoGerb Publishing brings manuscripts to market/i,
+      }),
+    ).toBeInTheDocument()
+  })
+
+  it('renders platform details for catalog workflows', () => {
+    render(<PlatformSection />)
+
+    expect(
+      screen.getByRole('heading', { level: 2, name: 'Integrated publishing console' }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', { level: 2, name: 'Collaborative editorial workflows' }),
+    ).toBeInTheDocument()
+  })
+
+  it('renders distribution capabilities overview', () => {
+    render(<DistributionSection />)
+
+    expect(
+      screen.getByRole('heading', { level: 2, name: 'Distribution channels' }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', { level: 2, name: 'Direct-to-audience storefronts' }),
+    ).toBeInTheDocument()
+  })
+
+  it('renders resource program highlights', () => {
+    render(<ResourcesSection />)
+
+    expect(screen.getByRole('heading', { level: 2, name: 'Author onboarding' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { level: 2, name: 'Marketing toolkit' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { level: 2, name: 'Compliance resources' })).toBeInTheDocument()
+  })
+
+  it('renders newsletter subscription form', () => {
+    render(<NewsletterSection />)
+
+    expect(screen.getByRole('form', { name: 'Newsletter sign up' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Subscribe' })).toBeInTheDocument()
+  })
+
+  it('renders the partner portal section with the protected wrapper', () => {
+    render(<PartnerPortalSection logoutUri="/logout" />)
+
+    expect(screen.getByRole('heading', { level: 2, name: 'Partner operations portal' })).toBeInTheDocument()
+    expect(mockProtected).toHaveBeenCalledWith(expect.objectContaining({ logoutUri: '/logout' }))
+    expect(screen.getByTestId('welcome-component')).toBeInTheDocument()
+  })
+})

--- a/websites/guidogerbpublishing.com/src/website-components/sections/index.js
+++ b/websites/guidogerbpublishing.com/src/website-components/sections/index.js
@@ -1,0 +1,6 @@
+export { HeroSection } from './HeroSection.jsx'
+export { PlatformSection } from './PlatformSection.jsx'
+export { DistributionSection } from './DistributionSection.jsx'
+export { ResourcesSection } from './ResourcesSection.jsx'
+export { NewsletterSection } from './NewsletterSection.jsx'
+export { PartnerPortalSection } from './PartnerPortalSection.jsx'


### PR DESCRIPTION
## Summary
- extract the publishing landing page sections from `App.jsx` into dedicated components for readability
- compose the app shell with the new section exports and mark the modularization task complete
- add smoke tests that render each marketing section and ensure the partner portal passes through the protected shell

## Testing
- pnpm --filter websites-guidogerbpublishing test

------
https://chatgpt.com/codex/tasks/task_e_68cdf32482948324894c92fff4ddbc76