### PR TITLE
Refactor GaryGerber marketing sections into reusable components

### DIFF
--- a/websites/garygerber.com/src/App.jsx
+++ b/websites/garygerber.com/src/App.jsx
@@ -1,10 +1,15 @@
 import { useCallback, useEffect, useState } from 'react'
-import Protected from '@guidogerb/components-pages-protected'
 import { Footer } from '@guidogerb/footer'
 import { Header, HeaderContextProvider } from '@guidogerb/header'
 import './App.css'
 import headerSettings from './headerSettings.js'
 import footerSettings from './footerSettings.js'
+import AboutPressSection from './website-components/about-press/index.jsx'
+import ConsultingSection from './website-components/consulting-section/index.jsx'
+import NewsletterSignupSection from './website-components/newsletter-signup/index.jsx'
+import ProgramsHeroSection from './website-components/programs-hero/index.jsx'
+import RecordingsEducationSection from './website-components/recordings-education/index.jsx'
+import RehearsalRoomSection from './website-components/rehearsal-room/index.jsx'
 import Welcome from './website-components/welcome-page/index.jsx'
 
 const SECTION_MAP = {
@@ -110,149 +115,14 @@ function App() {
         <Header activePath={activePath} onNavigate={handleNavigate} />
 
         <main className="app-main">
-          <section className="hero" id="programs">
-            <p className="eyebrow">Seasonal programs crafted for story-driven concerts</p>
-            <h1>
-              Gary Gerber shapes performances that stay with audiences long after the final encore.
-            </h1>
-            <p className="lede">
-              From symphony halls to intimate salons, Gary partners with presenters to build
-              immersive concerts, residencies, and education series that highlight local composers
-              and community voices.
-            </p>
-            <dl className="hero-highlights" aria-label="Program highlights">
-              <div>
-                <dt>30+</dt>
-                <dd>orchestral and chamber premieres across North America</dd>
-              </div>
-              <div>
-                <dt>12</dt>
-                <dd>artist-in-residence collaborations with universities and conservatories</dd>
-              </div>
-              <div>
-                <dt>100k+</dt>
-                <dd>listeners reached through live broadcasts and streaming performances</dd>
-              </div>
-            </dl>
-          </section>
-
-          <section className="content-grid" id="consulting">
-            <article>
-              <h2>Residencies &amp; masterclasses</h2>
-              <p>
-                Partner with Gary to curate multi-day engagements that pair public performances with
-                student workshops, collaborative rehearsals, and composer roundtables tailored to
-                your campus or festival.
-              </p>
-            </article>
-            <article>
-              <h2>Program development</h2>
-              <p>
-                Need a fresh recital concept or community outreach program? Gary works alongside
-                artistic directors to develop thematic concerts, interactive talks, and outreach
-                experiences that resonate with your audience.
-              </p>
-            </article>
-          </section>
-
-          <section className="content-grid" id="recordings">
-            <article>
-              <h2>Latest recordings</h2>
-              <ul className="feature-list">
-                <li>
-                  <h3>"Northern Lights"</h3>
-                  <p>
-                    Atmospheric piano works inspired by Nordic folklore, featuring collaborations
-                    with string quartet Pulse.
-                  </p>
-                </li>
-                <li>
-                  <h3>"Stories in Transit"</h3>
-                  <p>
-                    A live album captured during the 2024 Rail Lines residency, blending
-                    improvisation with commuter soundscapes.
-                  </p>
-                </li>
-                <li>
-                  <h3>"Field Notes"</h3>
-                  <p>
-                    Commissioned pieces for wind ensemble documenting national park sound walks with
-                    student composers.
-                  </p>
-                </li>
-              </ul>
-            </article>
-            <article id="education">
-              <h2>Studio resources</h2>
-              <p>
-                Access curriculum guides, repertoire suggestions, and rehearsal exercises crafted
-                from decades of teaching in conservatories and community programs.
-              </p>
-              <ul className="feature-list">
-                <li>Weekly warm-up sequences for mixed-ability ensembles</li>
-                <li>Improvisation prompts for student composers</li>
-                <li>Lesson plans that connect repertoire to local history</li>
-              </ul>
-            </article>
-          </section>
-
-          <section className="content-grid" id="about">
-            <article>
-              <h2>About Gary</h2>
-              <p>
-                Gary Gerber is an award-winning composer and pianist whose work bridges classical
-                traditions with contemporary storytelling. He has collaborated with the Minnesota
-                Orchestra, Banff Centre for Arts and Creativity, and community ensembles around the
-                globe.
-              </p>
-            </article>
-            <article id="press">
-              <h2>Press highlights</h2>
-              <p className="quote">
-                “Gerber’s performances invite the audience into the score—equal parts virtuosity and
-                welcome.”
-              </p>
-              <p className="quote-attribution">— The Chronicle of Chamber Music</p>
-            </article>
-          </section>
-
-          <section className="newsletter" id="newsletter">
-            <div>
-              <h2>Join the studio letter</h2>
-              <p>
-                Get quarterly notes on upcoming programs, new recordings, and behind-the-scenes
-                stories from Gary’s collaborations with composers, dancers, and filmmakers.
-              </p>
-            </div>
-            <form
-              className="newsletter-form"
-              aria-label="Newsletter sign up"
-              onSubmit={(event) => event.preventDefault()}
-            >
-              <label htmlFor="newsletter-email" className="visually-hidden">
-                Email address
-              </label>
-              <input
-                id="newsletter-email"
-                type="email"
-                name="email"
-                placeholder="you@example.com"
-                autoComplete="email"
-              />
-              <button type="submit">Notify me</button>
-            </form>
-          </section>
-
-          <section className="protected" id="client-access">
-            <h2>Client rehearsal room</h2>
-            <p className="protected-copy">
-              Presenters and collaborators can review rehearsal notes, download scores, and
-              coordinate logistics once signed in.
-            </p>
-            <Protected logoutUri={import.meta.env.VITE_LOGOUT_URI}>
-              <Welcome />
-            </Protected>
-          </section>
+          <ProgramsHeroSection />
+          <ConsultingSection />
+          <RecordingsEducationSection />
+          <AboutPressSection />
+          <NewsletterSignupSection />
+          <RehearsalRoomSection logoutUri={import.meta.env.VITE_LOGOUT_URI}>
+            <Welcome />
+          </RehearsalRoomSection>
         </main>
 
         <Footer {...footerSettings} onNavigate={handleNavigate} id="contact">

--- a/websites/garygerber.com/src/README.md
+++ b/websites/garygerber.com/src/README.md
@@ -5,4 +5,5 @@ Source files for the Gary Gerber artist site.
 - `main.jsx` — initializes the React tree.
 - `App.jsx` — orchestrates smooth-scroll navigation across marketing sections and the protected rehearsal portal.
 - `headerSettings.js` / `footerSettings.js` — tenant navigation and footer metadata.
+- `website-components/programs-hero`, `consulting-section`, `recordings-education`, `about-press`, `newsletter-signup`, `rehearsal-room` — reusable sections rendered by `App.jsx`.
 - `website-components/welcome-page/` — collaborator welcome card shown after authentication.

--- a/websites/garygerber.com/src/tasks.md
+++ b/websites/garygerber.com/src/tasks.md
@@ -3,5 +3,5 @@
 | name                                  | createdDate | lastUpdatedDate | completedDate | status   | description                                                                                 |
 | ------------------------------------- | ----------- | --------------- | ------------- | -------- | ------------------------------------------------------------------------------------------- |
 | Record source module responsibilities | 2025-09-19  | 2025-09-19      | 2025-09-19    | complete | README documents the roles of `App.jsx`, navigation settings, and the welcome component.    |
-| Extract reusable sections             | 2025-09-19  | 2025-09-19      | -             | todo     | Factor `App.jsx` into reusable section components (Programs, Consulting, Recordings, etc.). |
+| Extract reusable sections             | 2025-09-19  | 2025-09-19      | 2025-09-19    | complete | Factor `App.jsx` into reusable section components (Programs, Consulting, Recordings, etc.). |
 | Wire rehearsal portal navigation      | 2025-09-19  | 2025-09-19      | -             | todo     | Add routing to dedicated rehearsal pages once content is authored.                          |

--- a/websites/garygerber.com/src/website-components/__tests__/sections.test.jsx
+++ b/websites/garygerber.com/src/website-components/__tests__/sections.test.jsx
@@ -1,0 +1,75 @@
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockProtected } = vi.hoisted(() => ({
+  mockProtected: vi.fn(),
+}))
+
+vi.mock('@guidogerb/components-pages-protected', () => ({
+  __esModule: true,
+  default: (props) => {
+    mockProtected(props)
+    return <div data-testid="protected-mock">{props.children}</div>
+  },
+}))
+
+import AboutPressSection from '../about-press/index.jsx'
+import ConsultingSection from '../consulting-section/index.jsx'
+import NewsletterSignupSection from '../newsletter-signup/index.jsx'
+import ProgramsHeroSection from '../programs-hero/index.jsx'
+import RecordingsEducationSection from '../recordings-education/index.jsx'
+import RehearsalRoomSection from '../rehearsal-room/index.jsx'
+
+describe('Gary Gerber marketing sections', () => {
+  beforeEach(() => {
+    mockProtected.mockClear()
+  })
+
+  it('renders the programs hero section without crashing', () => {
+    render(<ProgramsHeroSection />)
+    expect(
+      screen.getByRole('heading', {
+        level: 1,
+        name: /Gary Gerber shapes performances that stay with audiences long after the final encore/i,
+      }),
+    ).toBeInTheDocument()
+  })
+
+  it('renders consulting services content', () => {
+    render(<ConsultingSection />)
+    expect(screen.getByRole('heading', { level: 2, name: 'Residencies & masterclasses' })).toBeInTheDocument()
+  })
+
+  it('renders recordings and studio resources highlights', () => {
+    render(<RecordingsEducationSection />)
+    expect(screen.getByRole('heading', { level: 2, name: 'Latest recordings' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { level: 2, name: 'Studio resources' })).toBeInTheDocument()
+  })
+
+  it('renders about and press information', () => {
+    render(<AboutPressSection />)
+    expect(screen.getByRole('heading', { level: 2, name: 'About Gary' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { level: 2, name: 'Press highlights' })).toBeInTheDocument()
+  })
+
+  it('renders the newsletter signup form once', () => {
+    render(<NewsletterSignupSection />)
+    expect(screen.getByRole('form', { name: /Newsletter sign up/i })).toBeInTheDocument()
+  })
+
+  it('renders the rehearsal room guard and forwards logout URI', () => {
+    render(
+      <RehearsalRoomSection logoutUri="/logout">
+        <span>Portal content</span>
+      </RehearsalRoomSection>,
+    )
+
+    expect(screen.getByRole('heading', { level: 2, name: 'Client rehearsal room' })).toBeInTheDocument()
+    expect(mockProtected).toHaveBeenCalledTimes(1)
+    expect(mockProtected).toHaveBeenCalledWith(
+      expect.objectContaining({
+        logoutUri: '/logout',
+      }),
+    )
+  })
+})

--- a/websites/garygerber.com/src/website-components/about-press/index.jsx
+++ b/websites/garygerber.com/src/website-components/about-press/index.jsx
@@ -1,0 +1,22 @@
+export default function AboutPressSection() {
+  return (
+    <section className="content-grid" id="about">
+      <article>
+        <h2>About Gary</h2>
+        <p>
+          Gary Gerber is an award-winning composer and pianist whose work bridges classical
+          traditions with contemporary storytelling. He has collaborated with the Minnesota
+          Orchestra, Banff Centre for Arts and Creativity, and community ensembles around the globe.
+        </p>
+      </article>
+      <article id="press">
+        <h2>Press highlights</h2>
+        <p className="quote">
+          “Gerber’s performances invite the audience into the score—equal parts virtuosity and
+          welcome.”
+        </p>
+        <p className="quote-attribution">— The Chronicle of Chamber Music</p>
+      </article>
+    </section>
+  )
+}

--- a/websites/garygerber.com/src/website-components/consulting-section/index.jsx
+++ b/websites/garygerber.com/src/website-components/consulting-section/index.jsx
@@ -1,0 +1,22 @@
+export default function ConsultingSection() {
+  return (
+    <section className="content-grid" id="consulting">
+      <article>
+        <h2>Residencies &amp; masterclasses</h2>
+        <p>
+          Partner with Gary to curate multi-day engagements that pair public performances with
+          student workshops, collaborative rehearsals, and composer roundtables tailored to your
+          campus or festival.
+        </p>
+      </article>
+      <article>
+        <h2>Program development</h2>
+        <p>
+          Need a fresh recital concept or community outreach program? Gary works alongside artistic
+          directors to develop thematic concerts, interactive talks, and outreach experiences that
+          resonate with your audience.
+        </p>
+      </article>
+    </section>
+  )
+}

--- a/websites/garygerber.com/src/website-components/newsletter-signup/index.jsx
+++ b/websites/garygerber.com/src/website-components/newsletter-signup/index.jsx
@@ -1,0 +1,26 @@
+export default function NewsletterSignupSection() {
+  return (
+    <section className="newsletter" id="newsletter">
+      <div>
+        <h2>Join the studio letter</h2>
+        <p>
+          Get quarterly notes on upcoming programs, new recordings, and behind-the-scenes stories
+          from Gary’s collaborations with composers, dancers, and filmmakers.
+        </p>
+      </div>
+      <form className="newsletter-form" aria-label="Newsletter sign up" onSubmit={(event) => event.preventDefault()}>
+        <label htmlFor="newsletter-email" className="visually-hidden">
+          Email address
+        </label>
+        <input
+          id="newsletter-email"
+          type="email"
+          name="email"
+          placeholder="you@example.com"
+          autoComplete="email"
+        />
+        <button type="submit">Notify me</button>
+      </form>
+    </section>
+  )
+}

--- a/websites/garygerber.com/src/website-components/programs-hero/index.jsx
+++ b/websites/garygerber.com/src/website-components/programs-hero/index.jsx
@@ -1,0 +1,27 @@
+export default function ProgramsHeroSection() {
+  return (
+    <section className="hero" id="programs">
+      <p className="eyebrow">Seasonal programs crafted for story-driven concerts</p>
+      <h1>Gary Gerber shapes performances that stay with audiences long after the final encore.</h1>
+      <p className="lede">
+        From symphony halls to intimate salons, Gary partners with presenters to build immersive
+        concerts, residencies, and education series that highlight local composers and community
+        voices.
+      </p>
+      <dl className="hero-highlights" aria-label="Program highlights">
+        <div>
+          <dt>30+</dt>
+          <dd>orchestral and chamber premieres across North America</dd>
+        </div>
+        <div>
+          <dt>12</dt>
+          <dd>artist-in-residence collaborations with universities and conservatories</dd>
+        </div>
+        <div>
+          <dt>100k+</dt>
+          <dd>listeners reached through live broadcasts and streaming performances</dd>
+        </div>
+      </dl>
+    </section>
+  )
+}

--- a/websites/garygerber.com/src/website-components/recordings-education/index.jsx
+++ b/websites/garygerber.com/src/website-components/recordings-education/index.jsx
@@ -1,0 +1,44 @@
+export default function RecordingsEducationSection() {
+  return (
+    <section className="content-grid" id="recordings">
+      <article>
+        <h2>Latest recordings</h2>
+        <ul className="feature-list">
+          <li>
+            <h3>"Northern Lights"</h3>
+            <p>
+              Atmospheric piano works inspired by Nordic folklore, featuring collaborations with
+              string quartet Pulse.
+            </p>
+          </li>
+          <li>
+            <h3>"Stories in Transit"</h3>
+            <p>
+              A live album captured during the 2024 Rail Lines residency, blending improvisation with
+              commuter soundscapes.
+            </p>
+          </li>
+          <li>
+            <h3>"Field Notes"</h3>
+            <p>
+              Commissioned pieces for wind ensemble documenting national park sound walks with
+              student composers.
+            </p>
+          </li>
+        </ul>
+      </article>
+      <article id="education">
+        <h2>Studio resources</h2>
+        <p>
+          Access curriculum guides, repertoire suggestions, and rehearsal exercises crafted from
+          decades of teaching in conservatories and community programs.
+        </p>
+        <ul className="feature-list">
+          <li>Weekly warm-up sequences for mixed-ability ensembles</li>
+          <li>Improvisation prompts for student composers</li>
+          <li>Lesson plans that connect repertoire to local history</li>
+        </ul>
+      </article>
+    </section>
+  )
+}

--- a/websites/garygerber.com/src/website-components/rehearsal-room/index.jsx
+++ b/websites/garygerber.com/src/website-components/rehearsal-room/index.jsx
@@ -1,0 +1,14 @@
+import Protected from '@guidogerb/components-pages-protected'
+
+export default function RehearsalRoomSection({ children, logoutUri }) {
+  return (
+    <section className="protected" id="client-access">
+      <h2>Client rehearsal room</h2>
+      <p className="protected-copy">
+        Presenters and collaborators can review rehearsal notes, download scores, and coordinate
+        logistics once signed in.
+      </p>
+      <Protected logoutUri={logoutUri}>{children}</Protected>
+    </section>
+  )
+}


### PR DESCRIPTION
## Summary
- extract Gary Gerber marketing sections into dedicated website components and consume them from `App.jsx`
- document the new section modules and mark the reusable sections task complete
- add Vitest coverage that smoke-tests each visual section and ensures the rehearsal guard forwards its logout URI

## Testing
- pnpm --filter websites-garygerber test

------
https://chatgpt.com/codex/tasks/task_e_68cdf6cbb4788324a72dd4510ad2d9ed