### PR TITLE
Parameterize publishing partner resources

### DIFF
--- a/websites/guidogerbpublishing.com/src/partnerResources.js
+++ b/websites/guidogerbpublishing.com/src/partnerResources.js
@@ -1,0 +1,45 @@
+const DEFAULT_RELEASE_CALENDAR_HREF = '/files/release-calendar.xlsx'
+const DEFAULT_ROYALTY_TEMPLATE_HREF = '/files/royalty-report-sample.pdf'
+const DEFAULT_OPERATIONS_EMAIL = 'partners@guidogerbpublishing.com'
+const DEFAULT_OPERATIONS_EMAIL_SUBJECT = 'Catalog update request'
+
+const env = import.meta.env ?? {}
+
+const releaseCalendarHref =
+  env.VITE_PARTNER_RESOURCES_RELEASE_CALENDAR_URL ?? DEFAULT_RELEASE_CALENDAR_HREF
+
+const royaltyTemplateHref =
+  env.VITE_PARTNER_RESOURCES_ROYALTY_TEMPLATE_URL ?? DEFAULT_ROYALTY_TEMPLATE_HREF
+
+const operationsEmail =
+  env.VITE_PARTNER_RESOURCES_OPERATIONS_EMAIL ?? DEFAULT_OPERATIONS_EMAIL
+
+const operationsEmailSubject =
+  env.VITE_PARTNER_RESOURCES_OPERATIONS_EMAIL_SUBJECT ?? DEFAULT_OPERATIONS_EMAIL_SUBJECT
+
+function createMailtoHref(address, subject) {
+  if (!address) return ''
+
+  if (address.startsWith('mailto:')) {
+    return address
+  }
+
+  const baseHref = `mailto:${address}`
+
+  if (!subject) {
+    return baseHref
+  }
+
+  const separator = baseHref.includes('?') ? '&' : '?'
+  return `${baseHref}${separator}subject=${encodeURIComponent(subject)}`
+}
+
+const operationsEmailHref = createMailtoHref(operationsEmail, operationsEmailSubject)
+
+export const partnerResources = {
+  releaseCalendarHref,
+  royaltyTemplateHref,
+  operationsEmailHref,
+}
+
+export default partnerResources

--- a/websites/guidogerbpublishing.com/src/website-components/welcome-page/README.md
+++ b/websites/guidogerbpublishing.com/src/website-components/welcome-page/README.md
@@ -6,3 +6,5 @@ contact routes once the user signs in via Cognito.
 - Renders partner-specific copy and quick links to downloadable resources.
 - Pulls the signed-in user's email when present to reinforce account context.
 - Allows nested children so the main app can insert additional partner widgets.
+- Resource URLs and contact email addresses resolve through `partnerResources.js`, which reads
+  `import.meta.env` overrides to keep operations configuration-driven.

--- a/websites/guidogerbpublishing.com/src/website-components/welcome-page/__tests__/Welcome.test.jsx
+++ b/websites/guidogerbpublishing.com/src/website-components/welcome-page/__tests__/Welcome.test.jsx
@@ -1,0 +1,116 @@
+import { render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockUseAuth } = vi.hoisted(() => ({
+  mockUseAuth: vi.fn(),
+}))
+
+vi.mock('@guidogerb/components-auth', () => ({
+  __esModule: true,
+  useAuth: mockUseAuth,
+}))
+
+async function renderWelcome(props = {}) {
+  const module = await import('../index.jsx')
+  const Welcome = module.default
+  return render(<Welcome {...props} />)
+}
+
+describe('Guidogerb Publishing welcome component', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.unstubAllEnvs()
+    mockUseAuth.mockReset()
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('renders an error message when authentication fails', async () => {
+    mockUseAuth.mockReturnValue({
+      error: { message: 'Network unavailable' },
+    })
+
+    const { container } = await renderWelcome()
+
+    const error = container.querySelector('.welcome-error')
+    expect(error).toBeInTheDocument()
+    expect(error).toHaveTextContent('Sign-in failed: Network unavailable')
+  })
+
+  it('shows a loading indicator while authentication is pending', async () => {
+    mockUseAuth.mockReturnValue({ isAuthenticated: false })
+
+    const { container } = await renderWelcome()
+
+    const loading = container.querySelector('.welcome-loading')
+    expect(loading).toBeInTheDocument()
+    expect(loading).toHaveTextContent('Loading partner workspace…')
+  })
+
+  it('renders partner details and default resource links when authenticated', async () => {
+    mockUseAuth.mockReturnValue({
+      isAuthenticated: true,
+      user: {
+        profile: {
+          name: 'Catalog Partner',
+          email: 'partner@example.com',
+        },
+      },
+    })
+
+    await renderWelcome({ children: <div data-testid="nested">Nested widget</div> })
+
+    expect(
+      screen.getByRole('heading', { level: 3, name: 'Welcome back, Catalog Partner!' }),
+    ).toBeInTheDocument()
+    expect(screen.getByText('Signed in as partner@example.com')).toBeInTheDocument()
+    expect(screen.getByTestId('nested')).toBeInTheDocument()
+
+    expect(
+      screen.getByRole('link', { name: /Download release calendar/i }),
+    ).toHaveAttribute('href', '/files/release-calendar.xlsx')
+    expect(
+      screen.getByRole('link', { name: /Review latest royalty template/i }),
+    ).toHaveAttribute('href', '/files/royalty-report-sample.pdf')
+    expect(
+      screen.getByRole('link', { name: /Email publishing operations/i }),
+    ).toHaveAttribute(
+      'href',
+      'mailto:partners@guidogerbpublishing.com?subject=Catalog%20update%20request',
+    )
+  })
+
+  it('uses configured resource URLs and mailto address when provided', async () => {
+    vi.stubEnv('VITE_PARTNER_RESOURCES_RELEASE_CALENDAR_URL', 'https://cdn.example.com/calendar.xlsx')
+    vi.stubEnv('VITE_PARTNER_RESOURCES_ROYALTY_TEMPLATE_URL', '/assets/royalty.pdf')
+    vi.stubEnv('VITE_PARTNER_RESOURCES_OPERATIONS_EMAIL', 'ops@example.com')
+    vi.stubEnv('VITE_PARTNER_RESOURCES_OPERATIONS_EMAIL_SUBJECT', 'Metadata sync request')
+
+    mockUseAuth.mockReturnValue({
+      isAuthenticated: true,
+      user: {
+        profile: {
+          'cognito:username': 'catalog-admin',
+        },
+      },
+    })
+
+    await renderWelcome()
+
+    expect(
+      screen.getByRole('heading', { level: 3, name: 'Welcome back, catalog-admin!' }),
+    ).toBeInTheDocument()
+
+    expect(
+      screen.getByRole('link', { name: /Download release calendar/i }),
+    ).toHaveAttribute('href', 'https://cdn.example.com/calendar.xlsx')
+    expect(
+      screen.getByRole('link', { name: /Review latest royalty template/i }),
+    ).toHaveAttribute('href', '/assets/royalty.pdf')
+    expect(
+      screen.getByRole('link', { name: /Email publishing operations/i }),
+    ).toHaveAttribute('href', 'mailto:ops@example.com?subject=Metadata%20sync%20request')
+  })
+})

--- a/websites/guidogerbpublishing.com/src/website-components/welcome-page/index.jsx
+++ b/websites/guidogerbpublishing.com/src/website-components/welcome-page/index.jsx
@@ -1,4 +1,5 @@
 import { useAuth } from '@guidogerb/components-auth'
+import partnerResources from '../../partnerResources.js'
 
 export default function Welcome({ children }) {
   const auth = useAuth()
@@ -14,6 +15,7 @@ export default function Welcome({ children }) {
   const name =
     auth?.user?.profile?.['cognito:username'] ?? auth?.user?.profile?.name ?? 'userNotAvailable'
   const email = auth?.user?.profile?.email
+  const { releaseCalendarHref, royaltyTemplateHref, operationsEmailHref } = partnerResources
 
   return (
     <div className="welcome-card">
@@ -25,13 +27,13 @@ export default function Welcome({ children }) {
       </p>
       <ul className="welcome-links">
         <li>
-          <a href="/files/release-calendar.xlsx">Download release calendar</a>
+          <a href={releaseCalendarHref}>Download release calendar</a>
         </li>
         <li>
-          <a href="/files/royalty-report-sample.pdf">Review latest royalty template</a>
+          <a href={royaltyTemplateHref}>Review latest royalty template</a>
         </li>
         <li>
-          <a href="mailto:partners@guidogerbpublishing.com?subject=Catalog%20update%20request">
+          <a href={operationsEmailHref}>
             Email publishing operations
           </a>
         </li>

--- a/websites/guidogerbpublishing.com/src/website-components/welcome-page/tasks.md
+++ b/websites/guidogerbpublishing.com/src/website-components/welcome-page/tasks.md
@@ -3,5 +3,5 @@
 | name                                        | createdDate | lastUpdatedDate | completedDate | status   | description                                                                                              |
 | ------------------------------------------- | ----------- | --------------- | ------------- | -------- | -------------------------------------------------------------------------------------------------------- |
 | Align partner messaging with publishing ops | 2025-09-19  | 2025-09-19      | 2025-09-19    | complete | Tailored the authenticated welcome card to highlight release calendars, royalty docs, and contact links. |
-| Fetch resource URLs from configuration      | 2025-09-19  | 2025-09-19      | -             | todo     | Move PDFs and mailto links into tenant config so they can change without redeploying the component.      |
-| Cover welcome flows with unit tests         | 2025-09-19  | 2025-09-19      | -             | todo     | Add tests for error, loading, and signed-in states to ensure partners get the right guidance.            |
+| Fetch resource URLs from configuration      | 2025-09-19  | 2025-09-21      | 2025-09-21    | complete | Move PDFs and mailto links into tenant config so they can change without redeploying the component.      |
+| Cover welcome flows with unit tests         | 2025-09-19  | 2025-09-21      | 2025-09-21    | complete | Add tests for error, loading, and signed-in states to ensure partners get the right guidance.            |


### PR DESCRIPTION
## Summary
- source the publishing welcome card resource links from a configuration module
- document the configuration flow and mark the component tasks complete
- add unit tests covering error, loading, authenticated states and config overrides

## Testing
- pnpm --filter websites-guidogerbpublishing test

------
https://chatgpt.com/codex/tasks/task_e_68cdfac725e08324b1030c9add0fbd2f