### PR TITLE
Parameterize Gary Gerber welcome resource links

### DIFF
--- a/websites/garygerber.com/src/rehearsalResources.js
+++ b/websites/garygerber.com/src/rehearsalResources.js
@@ -1,0 +1,43 @@
+const DEFAULT_STAGE_PLOT_HREF = '/files/stage-plot.pdf'
+const DEFAULT_REHEARSAL_CHECKLIST_HREF = '/files/rehearsal-checklist.pdf'
+const DEFAULT_PRODUCTION_EMAIL = 'hello@garygerber.com'
+const DEFAULT_PRODUCTION_EMAIL_SUBJECT = 'Collaboration Notes'
+
+const env = import.meta.env ?? {}
+
+const stagePlotHref = env.VITE_REHEARSAL_RESOURCES_STAGE_PLOT_URL ?? DEFAULT_STAGE_PLOT_HREF
+
+const rehearsalChecklistHref =
+  env.VITE_REHEARSAL_RESOURCES_CHECKLIST_URL ?? DEFAULT_REHEARSAL_CHECKLIST_HREF
+
+const productionEmail = env.VITE_REHEARSAL_RESOURCES_PRODUCTION_EMAIL ?? DEFAULT_PRODUCTION_EMAIL
+
+const productionEmailSubject =
+  env.VITE_REHEARSAL_RESOURCES_PRODUCTION_EMAIL_SUBJECT ?? DEFAULT_PRODUCTION_EMAIL_SUBJECT
+
+function createMailtoHref(address, subject) {
+  if (!address) return ''
+
+  if (address.startsWith('mailto:')) {
+    return address
+  }
+
+  const baseHref = `mailto:${address}`
+
+  if (!subject) {
+    return baseHref
+  }
+
+  const separator = baseHref.includes('?') ? '&' : '?'
+  return `${baseHref}${separator}subject=${encodeURIComponent(subject)}`
+}
+
+const productionEmailHref = createMailtoHref(productionEmail, productionEmailSubject)
+
+export const rehearsalResources = {
+  stagePlotHref,
+  rehearsalChecklistHref,
+  productionEmailHref,
+}
+
+export default rehearsalResources

--- a/websites/garygerber.com/src/website-components/welcome-page/README.md
+++ b/websites/garygerber.com/src/website-components/welcome-page/README.md
@@ -5,4 +5,11 @@ links to stage plots, checklists, and production contacts.
 
 - Leverages `useAuth()` to surface loading/error states during authentication.
 - Greets the signed-in user using Cognito profile data and highlights their email when available.
-- Lists rehearsal resources as simple anchors; future revisions will make these configurable.
+- Lists rehearsal resources from `rehearsalResources.js`, which reads defaults and optional
+  overrides from `import.meta.env`:
+  - `VITE_REHEARSAL_RESOURCES_STAGE_PLOT_URL`
+  - `VITE_REHEARSAL_RESOURCES_CHECKLIST_URL`
+  - `VITE_REHEARSAL_RESOURCES_PRODUCTION_EMAIL`
+  - `VITE_REHEARSAL_RESOURCES_PRODUCTION_EMAIL_SUBJECT`
+  When overrides are absent the component falls back to tenant defaults so deployments keep
+  working without extra configuration.

--- a/websites/garygerber.com/src/website-components/welcome-page/__tests__/Welcome.test.jsx
+++ b/websites/garygerber.com/src/website-components/welcome-page/__tests__/Welcome.test.jsx
@@ -1,0 +1,119 @@
+import { render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockUseAuth } = vi.hoisted(() => ({
+  mockUseAuth: vi.fn(),
+}))
+
+vi.mock('@guidogerb/components-auth', () => ({
+  __esModule: true,
+  useAuth: mockUseAuth,
+}))
+
+async function renderWelcome(props = {}) {
+  const module = await import('../index.jsx')
+  const Welcome = module.default
+  return render(<Welcome {...props} />)
+}
+
+describe('Gary Gerber welcome component', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.unstubAllEnvs()
+    mockUseAuth.mockReset()
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('renders an error message when authentication fails', async () => {
+    mockUseAuth.mockReturnValue({
+      error: { message: 'Sign-in blocked' },
+    })
+
+    const { container } = await renderWelcome()
+
+    const error = container.querySelector('.welcome-error')
+    expect(error).toBeInTheDocument()
+    expect(error).toHaveTextContent('Sign-in failed: Sign-in blocked')
+  })
+
+  it('shows a loading indicator while authentication resolves', async () => {
+    mockUseAuth.mockReturnValue({ isAuthenticated: false })
+
+    const { container } = await renderWelcome()
+
+    const loading = container.querySelector('.welcome-loading')
+    expect(loading).toBeInTheDocument()
+    expect(loading).toHaveTextContent('Loading rehearsal room…')
+  })
+
+  it('renders collaborator details and default rehearsal resources when authenticated', async () => {
+    mockUseAuth.mockReturnValue({
+      isAuthenticated: true,
+      user: {
+        profile: {
+          name: 'Touring Pianist',
+          email: 'pianist@example.com',
+        },
+      },
+    })
+
+    await renderWelcome({ children: <div data-testid="nested">Portal content</div> })
+
+    expect(
+      screen.getByRole('heading', { level: 3, name: 'Welcome back, Touring Pianist!' }),
+    ).toBeInTheDocument()
+    expect(screen.getByText('Signed in as pianist@example.com')).toBeInTheDocument()
+    expect(screen.getByTestId('nested')).toBeInTheDocument()
+
+    expect(screen.getByRole('link', { name: /Download latest stage plot/i })).toHaveAttribute(
+      'href',
+      '/files/stage-plot.pdf',
+    )
+    expect(screen.getByRole('link', { name: /Rehearsal checklist/i })).toHaveAttribute(
+      'href',
+      '/files/rehearsal-checklist.pdf',
+    )
+    expect(screen.getByRole('link', { name: /Email production team/i })).toHaveAttribute(
+      'href',
+      'mailto:hello@garygerber.com?subject=Collaboration%20Notes',
+    )
+  })
+
+  it('uses configured rehearsal resource links when environment overrides are provided', async () => {
+    vi.stubEnv('VITE_REHEARSAL_RESOURCES_STAGE_PLOT_URL', 'https://cdn.example.com/plots/latest.pdf')
+    vi.stubEnv('VITE_REHEARSAL_RESOURCES_CHECKLIST_URL', '/assets/custom-checklist.pdf')
+    vi.stubEnv('VITE_REHEARSAL_RESOURCES_PRODUCTION_EMAIL', 'production@example.com')
+    vi.stubEnv('VITE_REHEARSAL_RESOURCES_PRODUCTION_EMAIL_SUBJECT', 'Updated rehearsal notes')
+
+    mockUseAuth.mockReturnValue({
+      isAuthenticated: true,
+      user: {
+        profile: {
+          'cognito:username': 'guest-performer',
+        },
+      },
+    })
+
+    await renderWelcome()
+
+    expect(
+      screen.getByRole('heading', { level: 3, name: 'Welcome back, guest-performer!' }),
+    ).toBeInTheDocument()
+
+    expect(screen.getByRole('link', { name: /Download latest stage plot/i })).toHaveAttribute(
+      'href',
+      'https://cdn.example.com/plots/latest.pdf',
+    )
+    expect(screen.getByRole('link', { name: /Rehearsal checklist/i })).toHaveAttribute(
+      'href',
+      '/assets/custom-checklist.pdf',
+    )
+    expect(screen.getByRole('link', { name: /Email production team/i })).toHaveAttribute(
+      'href',
+      'mailto:production@example.com?subject=Updated%20rehearsal%20notes',
+    )
+  })
+})

--- a/websites/garygerber.com/src/website-components/welcome-page/index.jsx
+++ b/websites/garygerber.com/src/website-components/welcome-page/index.jsx
@@ -1,4 +1,5 @@
 import { useAuth } from '@guidogerb/components-auth'
+import rehearsalResources from '../../rehearsalResources.js'
 
 export default function Welcome({ children }) {
   const auth = useAuth()
@@ -14,6 +15,7 @@ export default function Welcome({ children }) {
   const name =
     auth?.user?.profile?.['cognito:username'] ?? auth?.user?.profile?.name ?? 'userNotAvailable'
   const email = auth?.user?.profile?.email
+  const { stagePlotHref, rehearsalChecklistHref, productionEmailHref } = rehearsalResources
 
   return (
     <div className="welcome-card">
@@ -25,13 +27,13 @@ export default function Welcome({ children }) {
       </p>
       <ul className="welcome-links">
         <li>
-          <a href="/files/stage-plot.pdf">Download latest stage plot</a>
+          <a href={stagePlotHref}>Download latest stage plot</a>
         </li>
         <li>
-          <a href="/files/rehearsal-checklist.pdf">Rehearsal checklist</a>
+          <a href={rehearsalChecklistHref}>Rehearsal checklist</a>
         </li>
         <li>
-          <a href="mailto:hello@garygerber.com?subject=Collaboration%20Notes">
+          <a href={productionEmailHref}>
             Email production team
           </a>
         </li>


### PR DESCRIPTION
## Summary
- externalize the Gary Gerber rehearsal resource URLs into a configurable module with environment overrides
- update the welcome component to consume the shared configuration and document the new env variables
- add Vitest coverage for error, loading, and authenticated states including environment overrides

## Testing
- pnpm --filter websites-garygerber test

------
https://chatgpt.com/codex/tasks/task_e_68cdfdf655508324b61b0700ab29b43c