### PR TITLE
feat(api-client): add typed endpoint helpers

### DIFF
--- a/@guidogerb/components/api-client/README.md
+++ b/@guidogerb/components/api-client/README.md
@@ -15,11 +15,40 @@ Typed HTTP client for the Phase‑1 API (API Gateway HTTP API).
 import { createClient } from '@guidogerb/components/api-client'
 import { getAccessToken } from '@guidogerb/auth'
 
-export const api = createClient({
+export const http = createClient({
   baseUrl: import.meta.env.VITE_API_BASE_URL!,
   getAccessToken,
   userAgent: 'guidogerb-web/1.0',
 })
-// Example
-const health = await api.get('/health')
+
+const health = await http.get('/health')
 ```
+
+## Typed endpoint helpers
+
+The package also ships opinionated helpers that expose typed operations for
+the Phase‑1 REST endpoints. The helpers build on `createClient` and surface
+structured responses for catalog search, downloads, entitlements, checkout,
+and admin workflows. TypeScript declaration files are bundled so consumers
+receive rich type information without additional tooling.
+
+```ts
+import { createApi } from '@guidogerb/components/api-client'
+import { getAccessToken } from '@guidogerb/auth'
+
+export const api = createApi({
+  baseUrl: import.meta.env.VITE_API_BASE_URL!,
+  getAccessToken,
+  userAgent: 'guidogerb-web/1.0',
+})
+
+const health = await api.health.check()
+const search = await api.catalog.search({ query: 'ambient', limit: 20 })
+const cart = await api.cart.create({
+  items: [{ sku: 'album_123', quantity: 1 }],
+  promoCode: 'FALL25',
+})
+```
+
+When needed, the raw HTTP client used by the helpers is available via the
+`api.http` property.

--- a/@guidogerb/components/api-client/index.d.ts
+++ b/@guidogerb/components/api-client/index.d.ts
@@ -1,0 +1,533 @@
+export type SearchParamsPrimitive = string | number | boolean
+export type SearchParamsValue =
+  | SearchParamsPrimitive
+  | Array<SearchParamsPrimitive>
+export type SearchParamsInput =
+  | string
+  | URLSearchParams
+  | Record<string, SearchParamsValue>
+
+export interface RetryOptions {
+  attempts?: number
+  delayMs?: number
+}
+
+export interface RequestOptions {
+  headers?: HeadersInit | Record<string, string>
+  searchParams?: SearchParamsInput
+  query?: SearchParamsInput
+  json?: unknown
+  body?: BodyInit | null
+  signal?: AbortSignal | null
+  retry?: RetryOptions
+}
+
+export interface Logger {
+  debug?: (...args: unknown[]) => void
+  warn?: (...args: unknown[]) => void
+}
+
+export interface CreateClientOptions {
+  baseUrl: string
+  getAccessToken?: () => string | Promise<string>
+  fetch?: typeof fetch
+  logger?: Logger
+  retry?: RetryOptions
+  defaultHeaders?: HeadersInit | Record<string, string>
+  userAgent?: string
+}
+
+export interface HttpResponse<T = unknown> {
+  data: T
+  response: Response
+}
+
+export interface HttpClient {
+  request<T = unknown>(method: string, path: string, options?: RequestOptions): Promise<HttpResponse<T>>
+  get<T = unknown>(path: string, options?: RequestOptions): Promise<T>
+  post<T = unknown>(path: string, options?: RequestOptions): Promise<T>
+  put<T = unknown>(path: string, options?: RequestOptions): Promise<T>
+  patch<T = unknown>(path: string, options?: RequestOptions): Promise<T>
+  delete<T = unknown>(path: string, options?: RequestOptions): Promise<T>
+}
+
+export declare class ApiError extends Error {
+  status?: number
+  statusText?: string
+  data?: unknown
+  response?: Response
+  request?: { method: string; url: string }
+  cause?: unknown
+}
+
+export declare function createClient(options: CreateClientOptions): HttpClient
+export { createClient as default }
+
+export interface HealthResponse {
+  status: string
+  service?: string
+  region?: string
+  version?: string
+  updatedAt?: string
+  [key: string]: unknown
+}
+
+export interface PageInfo {
+  total: number
+  hasNextPage: boolean
+  endCursor?: string | null
+}
+
+export interface CatalogFacetBucket {
+  value: string
+  label?: string
+  count: number
+}
+
+export interface CatalogFacets {
+  productTypes?: CatalogFacetBucket[]
+  fulfillment?: CatalogFacetBucket[]
+  tags?: CatalogFacetBucket[]
+  [key: string]: CatalogFacetBucket[] | undefined
+}
+
+export interface CatalogItemPrice {
+  amount: number
+  currency: string
+  interval?: string | null
+  trialDays?: number | null
+}
+
+export interface CatalogItemAvailability {
+  status: string
+  stock?: number | null
+  releaseDate?: string | null
+  fulfillment?: string
+  shipsIn?: string | null
+}
+
+export interface CatalogItemMedia {
+  type: string
+  url: string
+  preview?: string | null
+}
+
+export interface CatalogItem {
+  id: string
+  sku?: string
+  slug?: string
+  title: string
+  subtitle?: string
+  description?: string
+  type?: string
+  format?: string
+  tags: string[]
+  badges: string[]
+  rating?: number | null
+  duration?: number | null
+  productUrl?: string | null
+  previewUrl?: string | null
+  price: CatalogItemPrice
+  availability: CatalogItemAvailability
+  media: CatalogItemMedia[]
+  metadata?: Record<string, unknown>
+}
+
+export interface CatalogSearchParams {
+  query?: string
+  q?: string
+  type?: string | string[]
+  tags?: string | string[]
+  cursor?: string
+  limit?: number
+  sort?: string
+  locale?: string
+  tenantId?: string
+  tenant?: string
+}
+
+export interface CatalogSearchResponse {
+  items: CatalogItem[]
+  pageInfo: PageInfo
+  facets?: CatalogFacets
+  query?: {
+    q?: string
+    type?: string | string[]
+    tags?: string[]
+    sort?: string
+  }
+  metadata?: Record<string, unknown>
+}
+
+export interface CatalogItemRequest {
+  tenantId?: string
+  tenant?: string
+  locale?: string
+  includeRecommendations?: boolean
+}
+
+export type CatalogItemResponse = CatalogItem & {
+  longDescription?: string
+  content?: Record<string, unknown>
+  related?: CatalogItem[]
+}
+
+export interface CatalogArtistRequest {
+  tenantId?: string
+  tenant?: string
+  locale?: string
+}
+
+export interface ArtistSocialLinks {
+  website?: string
+  twitter?: string
+  instagram?: string
+  youtube?: string
+  tiktok?: string
+  [key: string]: string | undefined
+}
+
+export interface ArtistProfile {
+  id: string
+  slug: string
+  name: string
+  bio?: string
+  avatarUrl?: string | null
+  heroImageUrl?: string | null
+  social?: ArtistSocialLinks
+  featured?: CatalogItem[]
+  metadata?: Record<string, unknown>
+}
+
+export interface DownloadLinkRequest {
+  assetIds: string[]
+  tenantId?: string
+  format?: string
+  includeMetadata?: boolean
+  [key: string]: unknown
+}
+
+export interface DownloadLinkResponse {
+  url: string
+  token: string
+  expiresAt: string
+  contentType?: string
+  fileName?: string
+  size?: number
+  integrity?: string
+  [key: string]: unknown
+}
+
+export interface EntitlementUsage {
+  consumed: number
+  limit?: number | null
+  period?: string | null
+}
+
+export type EntitlementStatus = 'ACTIVE' | 'PENDING' | 'EXPIRED' | 'REVOKED' | string
+
+export interface Entitlement {
+  entitlementId: string
+  productId: string
+  sku?: string
+  title?: string
+  type?: string
+  status: EntitlementStatus
+  acquiredAt: string
+  expiresAt?: string | null
+  usage?: EntitlementUsage
+  metadata?: Record<string, unknown>
+}
+
+export interface EntitlementListParams {
+  tenantId?: string
+  tenant?: string
+  status?: EntitlementStatus | EntitlementStatus[]
+  cursor?: string
+  limit?: number
+}
+
+export interface EntitlementsResponse {
+  items: Entitlement[]
+  cursor?: string | null
+  hasNextPage?: boolean
+  updatedAt?: string
+}
+
+export type InvoiceStatus = 'draft' | 'open' | 'paid' | 'uncollectible' | 'void' | string
+
+export interface Invoice {
+  id: string
+  number: string
+  status: InvoiceStatus
+  subtotal: number
+  tax: number
+  total: number
+  currency: string
+  issuedAt: string
+  dueAt?: string | null
+  downloadUrl?: string | null
+  pdfUrl?: string | null
+  metadata?: Record<string, unknown>
+}
+
+export interface InvoiceListParams {
+  tenantId?: string
+  tenant?: string
+  status?: InvoiceStatus | InvoiceStatus[]
+  cursor?: string
+  limit?: number
+}
+
+export interface InvoicesResponse {
+  items: Invoice[]
+  cursor?: string | null
+  hasNextPage?: boolean
+}
+
+export interface CartItemInput {
+  sku: string
+  quantity?: number
+  price?: { amount: number; currency: string }
+  metadata?: Record<string, unknown>
+}
+
+export interface CartCreateRequest {
+  tenantId?: string
+  items: CartItemInput[]
+  promoCode?: string
+  customerId?: string
+  currency?: string
+  metadata?: Record<string, unknown>
+}
+
+export interface CartItem extends CartItemInput {
+  id: string
+  name?: string
+  description?: string
+  image?: string | null
+}
+
+export interface CartTotals {
+  subtotal: number
+  discount: number
+  tax: number
+  shipping: number
+  total: number
+  currency: string
+}
+
+export interface CartResponse {
+  id: string
+  items: CartItem[]
+  totals: CartTotals
+  promoCode?: string | null
+  updatedAt: string
+  metadata?: Record<string, unknown>
+}
+
+export type CheckoutMode = 'payment' | 'subscription' | string
+
+export interface CheckoutSessionRequest {
+  cartId?: string
+  successUrl: string
+  cancelUrl: string
+  customerEmail?: string
+  customerId?: string
+  currency?: string
+  mode?: CheckoutMode
+  allowPromotionCodes?: boolean
+  locale?: string
+  metadata?: Record<string, unknown>
+}
+
+export interface CheckoutSessionResponse {
+  sessionId: string
+  url?: string
+  clientSecret?: string
+  expiresAt: string
+  publishableKey?: string
+  metadata?: Record<string, unknown>
+}
+
+export interface CatalogImportRequest {
+  source: string
+  format?: string
+  dryRun?: boolean
+  upsert?: boolean
+  tenantId?: string
+  options?: Record<string, unknown>
+}
+
+export interface CatalogImportResponse {
+  jobId: string
+  status: 'accepted' | 'started' | string
+  summary?: {
+    created?: number
+    updated?: number
+    failed?: number
+  }
+  warnings?: string[]
+  metadata?: Record<string, unknown>
+}
+
+export interface DomainCreateRequest {
+  domain: string
+  tenantId: string
+  certificateArn?: string
+  autoVerify?: boolean
+  metadata?: Record<string, unknown>
+}
+
+export type DomainStatus = 'pending' | 'provisioning' | 'active' | 'failed' | string
+
+export interface DomainResponse {
+  id: string
+  domain: string
+  status: DomainStatus
+  createdAt: string
+  updatedAt?: string
+  validation?: {
+    method: string
+    value: string
+    status: 'pending' | 'verified' | 'failed' | string
+  }
+  metadata?: Record<string, unknown>
+}
+
+export interface UpdateUserRolesRequest {
+  roles: string[]
+  tenantId: string
+  notifyUser?: boolean
+  metadata?: Record<string, unknown>
+}
+
+export interface UserRolesResponse {
+  userId: string
+  roles: string[]
+  updatedAt: string
+  metadata?: Record<string, unknown>
+}
+
+export interface StoreCreateRequest {
+  name: string
+  tenantId: string
+  defaultCurrency: string
+  slug?: string
+  timezone?: string
+  metadata?: Record<string, unknown>
+}
+
+export type StoreStatus = 'draft' | 'active' | 'inactive' | string
+
+export interface StoreResponse {
+  id: string
+  slug: string
+  name: string
+  status: StoreStatus
+  defaultCurrency: string
+  createdAt: string
+  metadata?: Record<string, unknown>
+}
+
+export interface StoreProductPrice {
+  amount: number
+  currency: string
+  interval?: string | null
+}
+
+export interface StoreProductCreateRequest {
+  title: string
+  price: StoreProductPrice
+  sku?: string
+  description?: string
+  inventory?: {
+    stock?: number
+    allowBackorder?: boolean
+  }
+  fulfillment?: string
+  metadata?: Record<string, unknown>
+}
+
+export interface StoreProductResponse {
+  id: string
+  storeId: string
+  status: string
+  slug?: string
+  title: string
+  price: StoreProductPrice
+  availability?: CatalogItemAvailability
+  metadata?: Record<string, unknown>
+}
+
+export interface CreateApiOptions extends Partial<CreateClientOptions> {
+  client?: HttpClient
+}
+
+export interface HealthApi {
+  check(options?: RequestOptions): Promise<HealthResponse>
+}
+
+export interface CatalogApi {
+  search(params?: CatalogSearchParams, options?: RequestOptions): Promise<CatalogSearchResponse>
+  getItem(id: string, params?: CatalogItemRequest, options?: RequestOptions): Promise<CatalogItemResponse>
+  getArtist(slug: string, params?: CatalogArtistRequest, options?: RequestOptions): Promise<ArtistProfile>
+}
+
+export interface DownloadsApi {
+  createLink(input: DownloadLinkRequest, options?: RequestOptions): Promise<DownloadLinkResponse>
+}
+
+export interface AccountApi {
+  getEntitlements(params?: EntitlementListParams, options?: RequestOptions): Promise<EntitlementsResponse>
+  getInvoices(params?: InvoiceListParams, options?: RequestOptions): Promise<InvoicesResponse>
+}
+
+export interface CartApi {
+  create(input: CartCreateRequest, options?: RequestOptions): Promise<CartResponse>
+}
+
+export interface CheckoutApi {
+  createSession(input: CheckoutSessionRequest, options?: RequestOptions): Promise<CheckoutSessionResponse>
+}
+
+export interface AdminCatalogApi {
+  import(input: CatalogImportRequest, options?: RequestOptions): Promise<CatalogImportResponse>
+}
+
+export interface AdminDomainsApi {
+  create(input: DomainCreateRequest, options?: RequestOptions): Promise<DomainResponse>
+}
+
+export interface AdminUsersApi {
+  updateRoles(userId: string, input: UpdateUserRolesRequest, options?: RequestOptions): Promise<UserRolesResponse>
+}
+
+export interface AdminStoresApi {
+  create(input: StoreCreateRequest, options?: RequestOptions): Promise<StoreResponse>
+  createProduct(
+    storeId: string,
+    input: StoreProductCreateRequest,
+    options?: RequestOptions,
+  ): Promise<StoreProductResponse>
+}
+
+export interface AdminApi {
+  catalog: AdminCatalogApi
+  domains: AdminDomainsApi
+  users: AdminUsersApi
+  stores: AdminStoresApi
+}
+
+export interface ApiClient {
+  http: HttpClient
+  health: HealthApi
+  catalog: CatalogApi
+  downloads: DownloadsApi
+  me: AccountApi
+  cart: CartApi
+  checkout: CheckoutApi
+  admin: AdminApi
+}
+
+export declare function createApi(options: CreateApiOptions): ApiClient

--- a/@guidogerb/components/api-client/index.js
+++ b/@guidogerb/components/api-client/index.js
@@ -1,2 +1,3 @@
 export { createClient, ApiError } from './src/client.js'
+export { createApi } from './src/api.js'
 export { createClient as default } from './src/client.js'

--- a/@guidogerb/components/api-client/package.json
+++ b/@guidogerb/components/api-client/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "main": "./index.js",
   "module": "./index.js",
+  "types": "./index.d.ts",
   "scripts": {
     "test": "vitest run",
     "test:watch": "vitest"
@@ -17,6 +18,7 @@
   },
   "files": [
     "index.js",
+    "index.d.ts",
     "src"
   ],
   "dependencies": {},

--- a/@guidogerb/components/api-client/src/__tests__/api.test.js
+++ b/@guidogerb/components/api-client/src/__tests__/api.test.js
@@ -1,0 +1,216 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createApi, createClient } from '../../index.js'
+
+const jsonResponse = (body, init = {}) =>
+  new Response(JSON.stringify(body), {
+    status: 200,
+    headers: {
+      'content-type': 'application/json',
+      ...(init.headers ?? {}),
+    },
+    ...init,
+  })
+
+const headersToObject = (headers) => {
+  const entries = headers instanceof Headers ? headers.entries() : Object.entries(headers)
+  return Array.from(entries).reduce((acc, [key, value]) => {
+    acc[key] = value
+    return acc
+  }, {})
+}
+
+describe('createApi', () => {
+  it('uses a provided client instance and exposes the http transport', async () => {
+    const fetch = vi.fn().mockResolvedValue(jsonResponse({ status: 'ok' }))
+    const http = createClient({ baseUrl: 'https://api.example.com', fetch })
+
+    const api = createApi({ client: http })
+    expect(api.http).toBe(http)
+
+    const result = await api.health.check()
+    expect(result).toEqual({ status: 'ok' })
+    const [url, init] = fetch.mock.calls[0]
+    expect(url).toBe('https://api.example.com/health')
+    expect(init.method).toBe('GET')
+  })
+
+  it('builds catalog search URLs with typed filters', async () => {
+    const fetch = vi
+      .fn()
+      .mockResolvedValue(jsonResponse({ items: [], pageInfo: { total: 0, hasNextPage: false } }))
+
+    const api = createApi({ baseUrl: 'https://api.example.com/v1', fetch })
+
+    await api.catalog.search({
+      query: 'jazz',
+      type: ['album', 'book'],
+      tags: ['vinyl'],
+      limit: 10,
+      sort: 'featured',
+      tenantId: 'tenant-123',
+    })
+
+    const [url, init] = fetch.mock.calls[0]
+    expect(init.method).toBe('GET')
+    const parsed = new URL(url)
+    expect(parsed.pathname).toBe('/v1/public/catalog/search')
+    expect(parsed.searchParams.get('q')).toBe('jazz')
+    expect(parsed.searchParams.getAll('type')).toEqual(['album', 'book'])
+    expect(parsed.searchParams.getAll('tags')).toEqual(['vinyl'])
+    expect(parsed.searchParams.get('limit')).toBe('10')
+    expect(parsed.searchParams.get('sort')).toBe('featured')
+    expect(parsed.searchParams.get('tenant')).toBe('tenant-123')
+  })
+
+  it('encodes catalog identifiers and rejects missing values', async () => {
+    const fetch = vi
+      .fn()
+      .mockImplementation(() => Promise.resolve(jsonResponse({ id: 'prod-1' })))
+    const api = createApi({ baseUrl: 'https://api.example.com', fetch })
+
+    await api.catalog.getItem('prod/123', {
+      includeRecommendations: true,
+      tenant: 'tenant-1',
+    })
+
+    let call = fetch.mock.calls.at(-1)
+    let [url, init] = call
+    expect(init.method).toBe('GET')
+    const parsedItemUrl = new URL(url)
+    expect(parsedItemUrl.pathname).toBe('/public/catalog/items/prod%2F123')
+    expect(parsedItemUrl.searchParams.get('includeRecommendations')).toBe('true')
+    expect(parsedItemUrl.searchParams.get('tenant')).toBe('tenant-1')
+
+    await api.catalog.getArtist('artist/name', { tenantId: 'tenant-2' })
+    call = fetch.mock.calls.at(-1)
+    ;[url, init] = call
+    expect(init.method).toBe('GET')
+    const parsedArtistUrl = new URL(url)
+    expect(parsedArtistUrl.pathname).toBe('/public/artist/artist%2Fname')
+    expect(parsedArtistUrl.searchParams.get('tenant')).toBe('tenant-2')
+
+    expect(() => api.catalog.getItem('', {})).toThrow('catalog.getItem requires an id')
+    expect(() => api.catalog.getArtist('', {})).toThrow('catalog.getArtist requires a slug')
+  })
+
+  it('creates download links and validates payloads', async () => {
+    const fetch = vi.fn().mockResolvedValue(jsonResponse({ url: 'https://downloads.example.com/file' }))
+    const api = createApi({ baseUrl: 'https://api.example.com', fetch })
+
+    const payload = { assetIds: ['asset-1'], tenantId: 'tenant-1' }
+    await api.downloads.createLink(payload)
+    const [url, init] = fetch.mock.calls[0]
+    expect(url).toBe('https://api.example.com/downloads/link')
+    expect(init.method).toBe('POST')
+    const headers = headersToObject(init.headers)
+    expect(headers['content-type']).toBe('application/json')
+    expect(JSON.parse(init.body)).toEqual(payload)
+
+    expect(() => api.downloads.createLink({ assetIds: [] })).toThrow(
+      'downloads.createLink requires assetIds',
+    )
+  })
+
+  it('forwards tenant filters for account resources', async () => {
+    const fetch = vi
+      .fn()
+      .mockImplementation(() =>
+        Promise.resolve(jsonResponse({ items: [], cursor: null, hasNextPage: false })),
+      )
+    const api = createApi({ baseUrl: 'https://api.example.com', fetch })
+
+    await api.me.getEntitlements({
+      tenantId: 'tenant-1',
+      status: ['ACTIVE', 'PENDING'],
+      cursor: 'next-cursor',
+      limit: 25,
+    })
+    const [entitlementsUrl] = fetch.mock.calls[0]
+    const entitlementsParams = new URL(entitlementsUrl).searchParams
+    expect(entitlementsParams.get('tenant')).toBe('tenant-1')
+    expect(entitlementsParams.getAll('status')).toEqual(['ACTIVE', 'PENDING'])
+    expect(entitlementsParams.get('cursor')).toBe('next-cursor')
+    expect(entitlementsParams.get('limit')).toBe('25')
+
+    await api.me.getInvoices({ tenant: 'tenant-9', limit: 5 })
+    const [invoicesUrl] = fetch.mock.calls[1]
+    const invoicesParams = new URL(invoicesUrl).searchParams
+    expect(invoicesParams.get('tenant')).toBe('tenant-9')
+    expect(invoicesParams.get('limit')).toBe('5')
+  })
+
+  it('posts cart payloads and checkout sessions with required fields', async () => {
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse({ id: 'cart-1', items: [], totals: { subtotal: 0, discount: 0, tax: 0, shipping: 0, total: 0, currency: 'USD' } }),
+      )
+      .mockResolvedValueOnce(jsonResponse({ sessionId: 'sess_1', expiresAt: '2024-01-01T00:00:00Z' }))
+
+    const api = createApi({ baseUrl: 'https://api.example.com', fetch })
+
+    await api.cart.create({ items: [{ sku: 'sku-1', quantity: 1 }] })
+    let [, init] = fetch.mock.calls[0]
+    expect(init.method).toBe('POST')
+    expect(JSON.parse(init.body)).toEqual({ items: [{ sku: 'sku-1', quantity: 1 }] })
+
+    await api.checkout.createSession({
+      successUrl: 'https://example.com/success',
+      cancelUrl: 'https://example.com/cancel',
+    })
+    ;[, init] = fetch.mock.calls[1]
+    expect(init.method).toBe('POST')
+
+    expect(() => api.cart.create({})).toThrow('cart.create requires an items array')
+    expect(() => api.checkout.createSession({ successUrl: 'https://example.com', cancelUrl: '' })).toThrow(
+      'checkout.createSession requires successUrl and cancelUrl',
+    )
+  })
+
+  it('supports admin workflows with validation and correctly scoped paths', async () => {
+    const fetch = vi.fn().mockImplementation(() => Promise.resolve(jsonResponse({ ok: true })))
+    const api = createApi({ baseUrl: 'https://api.example.com', fetch })
+
+    await api.admin.catalog.import({ source: 's3://bucket/catalog.json' })
+    await api.admin.domains.create({ domain: 'shop.example.com', tenantId: 'tenant-1' })
+    await api.admin.users.updateRoles('user-1', { tenantId: 'tenant-1', roles: ['admin'] })
+    await api.admin.stores.create({ name: 'Main Store', tenantId: 'tenant-1', defaultCurrency: 'USD' })
+    await api.admin.stores.createProduct('store-1', {
+      title: 'Album',
+      price: { amount: 1999, currency: 'USD' },
+    })
+
+    const paths = fetch.mock.calls.map(([url]) => new URL(url).pathname)
+    expect(paths).toEqual([
+      '/admin/catalog/import',
+      '/admin/domains',
+      '/admin/users/user-1/roles',
+      '/store/create',
+      '/store/store-1/products',
+    ])
+
+    const bodies = fetch.mock.calls.map(([, init]) => (init.body ? JSON.parse(init.body) : null))
+    expect(bodies[0]).toEqual({ source: 's3://bucket/catalog.json' })
+    expect(bodies[1]).toEqual({ domain: 'shop.example.com', tenantId: 'tenant-1' })
+    expect(bodies[2]).toEqual({ tenantId: 'tenant-1', roles: ['admin'] })
+    expect(bodies[3]).toEqual({ name: 'Main Store', tenantId: 'tenant-1', defaultCurrency: 'USD' })
+    expect(bodies[4]).toEqual({ title: 'Album', price: { amount: 1999, currency: 'USD' } })
+
+    expect(() => api.admin.catalog.import({})).toThrow('admin.catalog.import requires a source')
+    expect(() => api.admin.domains.create({ domain: 'x.com' })).toThrow(
+      'admin.domains.create requires domain and tenantId',
+    )
+    expect(() => api.admin.users.updateRoles('', { roles: ['admin'] })).toThrow(
+      'admin.users.updateRoles requires a userId',
+    )
+    expect(() => api.admin.users.updateRoles('user-1', { roles: [] })).toThrow(
+      'admin.users.updateRoles requires roles array',
+    )
+    expect(() => api.admin.stores.create({ name: 'Store' })).toThrow(
+      'admin.stores.create requires name, tenantId, and defaultCurrency',
+    )
+    expect(() =>
+      api.admin.stores.createProduct('store-1', { price: { amount: 1000, currency: 'USD' } }),
+    ).toThrow('admin.stores.createProduct requires title and price')
+  })
+})

--- a/@guidogerb/components/api-client/src/api.js
+++ b/@guidogerb/components/api-client/src/api.js
@@ -1,0 +1,200 @@
+import { createClient } from './client.js'
+
+const encodeSegment = (value) => {
+  if (value === undefined || value === null) {
+    throw new Error('Path segment value is required')
+  }
+  return encodeURIComponent(String(value))
+}
+
+const sanitizeSearchParams = (params) => {
+  if (!params) return undefined
+  const entries = Object.entries(params).filter(([_, value]) => {
+    if (value === undefined || value === null) return false
+    if (Array.isArray(value)) {
+      return value.length > 0
+    }
+    if (typeof value === 'string') {
+      return value.length > 0
+    }
+    return true
+  })
+
+  if (entries.length === 0) return undefined
+
+  return entries.reduce((acc, [key, value]) => {
+    acc[key] = value
+    return acc
+  }, {})
+}
+
+const applySearchParams = (options, searchParams) => {
+  if (!searchParams) return options ?? {}
+  if (!options) return { searchParams }
+  return { ...options, searchParams }
+}
+
+export const createApi = ({ client, ...options } = {}) => {
+  const http = client ?? createClient(options)
+
+  const health = {
+    check: (requestOptions) => http.get('/health', requestOptions),
+  }
+
+  const catalog = {
+    search: (params = {}, requestOptions) => {
+      const searchParams = sanitizeSearchParams({
+        q: params.query ?? params.q,
+        type: params.type,
+        tags: params.tags,
+        cursor: params.cursor,
+        limit: params.limit,
+        sort: params.sort,
+        tenant: params.tenantId ?? params.tenant,
+        locale: params.locale,
+      })
+      return http.get('/public/catalog/search', applySearchParams(requestOptions, searchParams))
+    },
+    getItem: (id, params = {}, requestOptions) => {
+      if (!id) {
+        throw new Error('catalog.getItem requires an id')
+      }
+      const searchParams = sanitizeSearchParams({
+        tenant: params.tenantId ?? params.tenant,
+        locale: params.locale,
+        includeRecommendations: params.includeRecommendations,
+      })
+      return http.get(
+        `/public/catalog/items/${encodeSegment(id)}`,
+        applySearchParams(requestOptions, searchParams),
+      )
+    },
+    getArtist: (slug, params = {}, requestOptions) => {
+      if (!slug) {
+        throw new Error('catalog.getArtist requires a slug')
+      }
+      const searchParams = sanitizeSearchParams({
+        tenant: params.tenantId ?? params.tenant,
+        locale: params.locale,
+      })
+      return http.get(
+        `/public/artist/${encodeSegment(slug)}`,
+        applySearchParams(requestOptions, searchParams),
+      )
+    },
+  }
+
+  const downloads = {
+    createLink: (payload, requestOptions) => {
+      if (!payload || !Array.isArray(payload.assetIds) || payload.assetIds.length === 0) {
+        throw new Error('downloads.createLink requires assetIds')
+      }
+      return http.post('/downloads/link', { ...(requestOptions ?? {}), json: payload })
+    },
+  }
+
+  const me = {
+    getEntitlements: (params = {}, requestOptions) => {
+      const searchParams = sanitizeSearchParams({
+        tenant: params.tenantId ?? params.tenant,
+        status: params.status,
+        cursor: params.cursor,
+        limit: params.limit,
+      })
+      return http.get('/me/entitlements', applySearchParams(requestOptions, searchParams))
+    },
+    getInvoices: (params = {}, requestOptions) => {
+      const searchParams = sanitizeSearchParams({
+        tenant: params.tenantId ?? params.tenant,
+        cursor: params.cursor,
+        limit: params.limit,
+        status: params.status,
+      })
+      return http.get('/me/invoices', applySearchParams(requestOptions, searchParams))
+    },
+  }
+
+  const cart = {
+    create: (payload, requestOptions) => {
+      if (!payload || !Array.isArray(payload.items)) {
+        throw new Error('cart.create requires an items array')
+      }
+      return http.post('/cart', { ...(requestOptions ?? {}), json: payload })
+    },
+  }
+
+  const checkout = {
+    createSession: (payload, requestOptions) => {
+      if (!payload?.successUrl || !payload?.cancelUrl) {
+        throw new Error('checkout.createSession requires successUrl and cancelUrl')
+      }
+      return http.post('/checkout/create-session', { ...(requestOptions ?? {}), json: payload })
+    },
+  }
+
+  const admin = {
+    catalog: {
+      import: (payload, requestOptions) => {
+        if (!payload?.source) {
+          throw new Error('admin.catalog.import requires a source')
+        }
+        return http.post('/admin/catalog/import', { ...(requestOptions ?? {}), json: payload })
+      },
+    },
+    domains: {
+      create: (payload, requestOptions) => {
+        if (!payload?.domain || !payload?.tenantId) {
+          throw new Error('admin.domains.create requires domain and tenantId')
+        }
+        return http.post('/admin/domains', { ...(requestOptions ?? {}), json: payload })
+      },
+    },
+    users: {
+      updateRoles: (userId, payload, requestOptions) => {
+        if (!userId) {
+          throw new Error('admin.users.updateRoles requires a userId')
+        }
+        if (!payload || !Array.isArray(payload.roles) || payload.roles.length === 0) {
+          throw new Error('admin.users.updateRoles requires roles array')
+        }
+        return http.post(`/admin/users/${encodeSegment(userId)}/roles`, {
+          ...(requestOptions ?? {}),
+          json: payload,
+        })
+      },
+    },
+    stores: {
+      create: (payload, requestOptions) => {
+        if (!payload?.name || !payload?.tenantId || !payload?.defaultCurrency) {
+          throw new Error('admin.stores.create requires name, tenantId, and defaultCurrency')
+        }
+        return http.post('/store/create', { ...(requestOptions ?? {}), json: payload })
+      },
+      createProduct: (storeId, payload, requestOptions) => {
+        if (!storeId) {
+          throw new Error('admin.stores.createProduct requires a storeId')
+        }
+        if (!payload?.title || !payload?.price) {
+          throw new Error('admin.stores.createProduct requires title and price')
+        }
+        return http.post(`/store/${encodeSegment(storeId)}/products`, {
+          ...(requestOptions ?? {}),
+          json: payload,
+        })
+      },
+    },
+  }
+
+  return {
+    http,
+    health,
+    catalog,
+    downloads,
+    me,
+    cart,
+    checkout,
+    admin,
+  }
+}
+
+export default createApi


### PR DESCRIPTION
## Summary
- add a `createApi` helper that wraps the HTTP client with typed endpoint groups and guardrails
- ship TypeScript declarations for the helper, export it from the package entrypoint, and update package metadata
- document the new usage pattern in the README

## Testing
- pnpm --filter @guidogerb/components-api test

------
https://chatgpt.com/codex/tasks/task_e_68ce07c144188324b74020fd86ac3fb2