### PR TITLE
feat: support AI streaming responses and router data APIs

### DIFF
--- a/@guidogerb/components/ai-support/tasks.md
+++ b/@guidogerb/components/ai-support/tasks.md
@@ -4,4 +4,4 @@
 | ----------------------------------- | ----------- | --------------- | ------------- | ----------- | ---------------------------------------------------------------------------------------------------------- |
 | Document guardrail and RAG hooks    | 2025-09-19  | 2025-09-19      | 2025-09-19    | complete    | Captured guardrail contracts, retriever expectations, and payload structure for implementers.              |
 | Persist chat transcripts per tenant | 2025-09-19  | 2025-09-19      | -             | in progress | Design storage adapters that archive conversations securely with optional tenant-level retention policies. |
-| Add streaming response support      | 2025-09-19  | 2025-09-19      | -             | todo        | Enhance the component to render partial assistant messages while the gateway streams tokens.               |
+| Add streaming response support      | 2025-09-19  | 2025-09-21      | 2025-09-21    | complete    | Enhance the component to render partial assistant messages while the gateway streams tokens.               |

--- a/@guidogerb/components/router/public/README.md
+++ b/@guidogerb/components/router/public/README.md
@@ -40,6 +40,40 @@ function MarketingApp() {
 `wrapElement` can be supplied to decorate every route element—for example to
 inject shared layouts or analytics boundaries—before the router renders it.
 
+### React Router data APIs
+
+Route definitions accept the full suite of React Router data API fields such as
+`loader`, `action`, `handle`, and `errorElement`. These entries are passed
+directly to the underlying router factory so `useLoaderData`, `defer`, and form
+actions work as expected.
+
+```jsx
+const routes = [
+  {
+    path: '/posts/:id',
+    loader: ({ params }) => fetchPost(params.id),
+    action: updatePost,
+    element: <PostDetail />, // PostDetail can call useLoaderData()
+  },
+]
+
+<PublicRouter router={createBrowserRouter} routes={routes} />
+```
+
+When the generated fallback experience is used, you can also supply data API
+options (like `loader`, `action`, `errorElement`, or `handle`) via
+`defaultFallback`:
+
+```jsx
+<PublicRouter
+  routes={[{ path: '/', element: <Home /> }]}
+  defaultFallback={{
+    loader: () => ({ supportUrl: '/support' }),
+    handle: { breadcrumb: 'Not Found' },
+  }}
+/>
+```
+
 ### Customising the generated fallback
 
 When the `fallback` prop is omitted, the router emits an accessible not-found

--- a/@guidogerb/components/router/public/src/createRouteObjects.jsx
+++ b/@guidogerb/components/router/public/src/createRouteObjects.jsx
@@ -102,8 +102,11 @@ const buildGeneratedFallbackDefinition = (config) => {
 
   const containerClass = [DEFAULT_FALLBACK_CLASS, options.className].filter(Boolean).join(' ')
 
-  return {
-    path: '*',
+  const fallbackRoute = {
+    path:
+      typeof options.path === 'string' && options.path.trim().length > 0
+        ? options.path.trim()
+        : '*',
     element: (
       <DefaultFallback
         title={title}
@@ -116,6 +119,26 @@ const buildGeneratedFallbackDefinition = (config) => {
     ),
     isFallback: true,
   }
+
+  const dataApiFields = [
+    'loader',
+    'action',
+    'lazy',
+    'errorElement',
+    'handle',
+    'shouldRevalidate',
+    'hasErrorBoundary',
+    'id',
+    'caseSensitive',
+  ]
+
+  for (const field of dataApiFields) {
+    if (Object.prototype.hasOwnProperty.call(options, field)) {
+      fallbackRoute[field] = options[field]
+    }
+  }
+
+  return fallbackRoute
 }
 
 function toRouteObject(route, wrapElement) {

--- a/@guidogerb/components/router/public/tasks.md
+++ b/@guidogerb/components/router/public/tasks.md
@@ -4,4 +4,4 @@
 | -------------------------------------- | ----------- | --------------- | ------------- | -------- | ----------------------------------------------------------------------------------------- |
 | Document PublicRouter wiring           | 2025-09-19  | 2025-09-19      | 2025-09-19    | complete | Explained how to feed route definitions, fallback elements, and wrappers into the helper. |
 | Support React Router data APIs         | 2025-09-19  | 2025-09-21      | 2025-09-21    | complete | Add helpers that accept loaders/actions and pass them through to the router factory.      |
-| Generate default 404 route scaffolding | 2025-09-19  | 2025-09-19      | -             | todo     | Provide a utility that emits a localized not-found route when tenants omit a fallback.    |
+| Generate default 404 route scaffolding | 2025-09-19  | 2025-09-21      | 2025-09-21    | complete | Provide a utility that emits a localized not-found route when tenants omit a fallback.    |

--- a/@guidogerb/components/router/public/tasks.md
+++ b/@guidogerb/components/router/public/tasks.md
@@ -3,5 +3,5 @@
 | name                                   | createdDate | lastUpdatedDate | completedDate | status   | description                                                                               |
 | -------------------------------------- | ----------- | --------------- | ------------- | -------- | ----------------------------------------------------------------------------------------- |
 | Document PublicRouter wiring           | 2025-09-19  | 2025-09-19      | 2025-09-19    | complete | Explained how to feed route definitions, fallback elements, and wrappers into the helper. |
-| Support React Router data APIs         | 2025-09-19  | 2025-09-19      | -             | todo     | Add helpers that accept loaders/actions and pass them through to the router factory.      |
+| Support React Router data APIs         | 2025-09-19  | 2025-09-21      | 2025-09-21    | complete | Add helpers that accept loaders/actions and pass them through to the router factory.      |
 | Generate default 404 route scaffolding | 2025-09-19  | 2025-09-19      | -             | todo     | Provide a utility that emits a localized not-found route when tenants omit a fallback.    |


### PR DESCRIPTION
## Summary
- add streaming detection and incremental rendering to `<AiSupport />` with tests and docs
- update PublicRouter helpers and docs to surface React Router data API fields including loaders/actions
- expand unit coverage to confirm generated fallbacks and routes carry data API configuration

## Testing
- pnpm -r --workspace-concurrency=1 test

------
https://chatgpt.com/codex/tasks/task_e_68cf040a2cf083249cfa7a78b3298383