### PR TITLE
Enhance POS invoice persistence and offline handoffs

### DIFF
--- a/@guidogerb/components/point-of-sale/package.json
+++ b/@guidogerb/components/point-of-sale/package.json
@@ -24,6 +24,7 @@
     "react": ">=19"
   },
   "dependencies": {
+    "@guidogerb/components-analytics": "workspace:*",
     "@guidogerb/components-catalog": "workspace:*",
     "@guidogerb/components-shopping-cart": "workspace:*",
     "@guidogerb/components-storage": "workspace:*",

--- a/@guidogerb/components/point-of-sale/src/PointOfSale.jsx
+++ b/@guidogerb/components/point-of-sale/src/PointOfSale.jsx
@@ -48,6 +48,111 @@ const buildInvoiceFromOrder = (order) => {
   }
 }
 
+const buildOrderFromInvoice = (invoice, { totals = {}, user } = {}) => {
+  if (!invoice) return null
+
+  const invoiceTotals = invoice.totals ?? {}
+  const amount = invoiceTotals.total ?? totals.total ?? 0
+  const currency = invoiceTotals.currency ?? totals.currency ?? 'USD'
+
+  return {
+    id: invoice.id ?? invoice.number ?? `order-${Date.now()}`,
+    number: invoice.number ?? invoice.id ?? `ORDER-${Date.now()}`,
+    status: invoice.status ?? 'PAID',
+    total: {
+      amount,
+      currency,
+    },
+    customer:
+      invoice.customer ??
+      (user
+        ? {
+            email: user.email,
+            name: user.name,
+          }
+        : null),
+    createdAt: invoice.issuedAt ?? new Date().toISOString(),
+    paymentIntentId: invoice.paymentIntentId ?? invoice.paymentIntent?.id ?? null,
+  }
+}
+
+const HANDOFF_STATUS_SYNCED = 'synced'
+const HANDOFF_STATUS_PENDING = 'pending'
+
+const createHandoffId = (entry) => {
+  if (!entry || typeof entry !== 'object') {
+    return `handoff-${Date.now()}-${Math.random().toString(16).slice(2)}`
+  }
+
+  return (
+    entry.id ??
+    entry.invoice?.id ??
+    entry.paymentIntentId ??
+    entry.order?.id ??
+    `handoff-${Date.now()}-${Math.random().toString(16).slice(2)}`
+  )
+}
+
+const normalizeHandoffEntries = (entries, limit = 5) => {
+  if (!Array.isArray(entries) || limit <= 0) return []
+
+  const normalized = []
+  const seen = new Set()
+
+  for (const entry of entries) {
+    if (!entry || typeof entry !== 'object') continue
+    const id = createHandoffId(entry)
+    if (seen.has(id)) continue
+    seen.add(id)
+    normalized.push({
+      ...entry,
+      id,
+      status: entry.status === HANDOFF_STATUS_PENDING ? HANDOFF_STATUS_PENDING : HANDOFF_STATUS_SYNCED,
+      createdAt: entry.createdAt ?? Date.now(),
+    })
+    if (normalized.length >= limit) break
+  }
+
+  return normalized
+}
+
+const handoffEntriesEqual = (a, b) => {
+  if (a === b) return true
+  if (!Array.isArray(a) || !Array.isArray(b) || a.length !== b.length) return false
+  for (let index = 0; index < a.length; index += 1) {
+    const left = a[index]
+    const right = b[index]
+    if (!left || !right) return false
+    if (left.id !== right.id) return false
+    if (left.status !== right.status) return false
+    if ((left.invoice?.id ?? null) !== (right.invoice?.id ?? null)) return false
+    if ((left.order?.id ?? null) !== (right.order?.id ?? null)) return false
+    if ((left.paymentIntentId ?? null) !== (right.paymentIntentId ?? null)) return false
+    if ((left.userId ?? null) !== (right.userId ?? null)) return false
+  }
+  return true
+}
+
+const mergeByKey = (existing = [], incoming = [], getKey = (item) => item?.id) => {
+  const map = new Map()
+
+  for (const item of existing) {
+    if (!item || typeof item !== 'object') continue
+    const key = getKey(item)
+    if (!key) continue
+    map.set(key, item)
+  }
+
+  for (const item of incoming) {
+    if (!item || typeof item !== 'object') continue
+    const key = getKey(item)
+    if (!key) continue
+    map.set(key, { ...map.get(key), ...item })
+  }
+
+  return Array.from(map.values())
+}
+
 const PointOfSaleExperience = ({
   stripe,
   stripeError,
@@ -65,6 +170,9 @@ const PointOfSaleExperience = ({
   onPaymentError,
   shouldAutoCreatePaymentIntent = true,
   createInvoiceMetadata,
+  handoffStorage,
+  handoffStorageKey = 'guidogerb.pos.handoffs',
+  maxStoredHandoffs = 5,
 }) => {
   const { items, totals, clearCart } = useCart()
   const {
@@ -88,6 +196,60 @@ const PointOfSaleExperience = ({
   const [checkoutError, setCheckoutError] = useState(null)
   const [isCreatingPaymentIntent, setIsCreatingPaymentIntent] = useState(false)
   const [paymentIntent, setPaymentIntent] = useState({ id: null, clientSecret: null })
+
+  const supportsHandoffs = Boolean(handoffStorage?.get && maxStoredHandoffs > 0)
+
+  const loadHandoffs = useCallback(() => {
+    if (!supportsHandoffs) return []
+    try {
+      const stored = handoffStorage.get?.(handoffStorageKey, [])
+      return normalizeHandoffEntries(stored, maxStoredHandoffs)
+    } catch (error) {
+      console.error('Failed to load POS handoffs', error)
+      return []
+    }
+  }, [handoffStorage, handoffStorageKey, maxStoredHandoffs, supportsHandoffs])
+
+  const [handoffs, setHandoffs] = useState(() => loadHandoffs())
+
+  useEffect(() => {
+    if (!supportsHandoffs) return
+    setHandoffs((prev) => {
+      const next = loadHandoffs()
+      return handoffEntriesEqual(prev, next) ? prev : next
+    })
+  }, [loadHandoffs, supportsHandoffs])
+
+  useEffect(() => {
+    if (!supportsHandoffs || typeof handoffStorage?.subscribe !== 'function') return undefined
+    const unsubscribe = handoffStorage.subscribe((event) => {
+      if (!event) return
+      if (event.type === 'clear' || event.key === undefined || event.key === handoffStorageKey) {
+        setHandoffs((prev) => {
+          const next = loadHandoffs()
+          return handoffEntriesEqual(prev, next) ? prev : next
+        })
+      } else if (event.type === 'set' && event.key === handoffStorageKey) {
+        const next = normalizeHandoffEntries(event.value, maxStoredHandoffs)
+        setHandoffs((prev) => (handoffEntriesEqual(prev, next) ? prev : next))
+      }
+    })
+    return unsubscribe
+  }, [handoffStorage, handoffStorageKey, loadHandoffs, maxStoredHandoffs, supportsHandoffs])
+
+  const updateHandoffs = useCallback(
+    (updater) => {
+      if (!handoffStorage?.set || maxStoredHandoffs <= 0) return
+      setHandoffs((prev) => {
+        const nextEntries = typeof updater === 'function' ? updater(prev) : updater ?? []
+        const normalized = normalizeHandoffEntries(nextEntries, maxStoredHandoffs)
+        if (handoffEntriesEqual(prev, normalized)) return prev
+        handoffStorage.set(handoffStorageKey, normalized)
+        return normalized
+      })
+    },
+    [handoffStorage, handoffStorageKey, maxStoredHandoffs],
+  )
 
   const posApi = useMemo(() => {
     if (api) return api
@@ -163,6 +325,27 @@ const PointOfSaleExperience = ({
     loadOrders()
     loadInvoices()
   }, [loadProducts, loadOrders, loadInvoices])
+
+  useEffect(() => {
+    if (!handoffs.length) return
+
+    const handoffInvoices = handoffs.map((entry) => entry.invoice).filter(Boolean)
+    if (handoffInvoices.length > 0) {
+      setInvoices((prev) => mergeByKey(prev, handoffInvoices, (item) => item?.id ?? item?.number))
+    }
+
+    const handoffOrders = handoffs.map((entry) => entry.order).filter(Boolean)
+    if (handoffOrders.length > 0) {
+      setOrders((prev) => mergeByKey(prev, handoffOrders, (item) => item?.id ?? item?.number))
+    }
+
+    if (!activeInvoice) {
+      const latestInvoice = handoffInvoices[0]
+      if (latestInvoice) {
+        setActiveInvoice(latestInvoice)
+      }
+    }
+  }, [activeInvoice, handoffs])
 
   const cartSnapshot = useMemo(
     () => ({
@@ -249,81 +432,127 @@ const PointOfSaleExperience = ({
         promoCode: totals.promoCode,
       }
 
-      try {
-        let invoiceResponse = null
-        if (posApi?.createInvoice) {
+      const metadataPayload = createInvoiceMetadata?.({
+        paymentIntent: paymentIntentResult,
+        cart: snapshot,
+        user,
+        context,
+      })
+
+      const fallbackInvoice = {
+        id: paymentIntentResult?.id ?? `invoice-${Date.now()}`,
+        number: paymentIntentResult?.id ?? `INV-${Date.now()}`,
+        status: paymentIntentResult?.status ?? 'SUCCEEDED',
+        issuedAt: new Date().toISOString(),
+        customer: { name: user?.name, email: user?.email },
+        items: snapshot.items,
+        totals: snapshot.totals,
+        paymentIntentId: paymentIntentResult?.id ?? null,
+      }
+
+      let invoiceResponse = null
+      let resolvedInvoice = fallbackInvoice
+      let orderRecord = null
+      let persistenceStatus = HANDOFF_STATUS_PENDING
+      let persistenceError = null
+
+      if (posApi?.createInvoice) {
+        try {
           invoiceResponse = await posApi.createInvoice({
             cart: snapshot,
             paymentIntent: paymentIntentResult,
             user,
-            metadata: createInvoiceMetadata?.({
-              paymentIntent: paymentIntentResult,
-              cart: snapshot,
-              user,
-              context,
-            }),
+            metadata: metadataPayload,
           })
+          resolvedInvoice =
+            invoiceResponse?.invoice ?? invoiceResponse ?? fallbackInvoice
+          persistenceStatus = HANDOFF_STATUS_SYNCED
+        } catch (error) {
+          persistenceError = error
+          resolvedInvoice = fallbackInvoice
         }
+      }
 
-        const resolvedInvoice = invoiceResponse?.invoice ??
-          invoiceResponse ?? {
-            id: paymentIntentResult?.id,
-            number: paymentIntentResult?.id,
-            status: paymentIntentResult?.status ?? 'SUCCEEDED',
-            issuedAt: new Date().toISOString(),
-            customer: { name: user?.name, email: user?.email },
-            items: snapshot.items,
-            totals: snapshot.totals,
-          }
+      if (!resolvedInvoice) {
+        resolvedInvoice = fallbackInvoice
+      }
 
-        setActiveInvoice(resolvedInvoice)
-        setInvoices((prev) => {
-          if (!resolvedInvoice) return prev
-          const exists = prev.some((entry) => entry.id === resolvedInvoice.id)
-          return exists ? prev : [resolvedInvoice, ...prev]
-        })
+      orderRecord =
+        invoiceResponse?.order ??
+        buildOrderFromInvoice(resolvedInvoice, { totals: snapshot.totals, user }) ??
+        buildOrderFromInvoice(fallbackInvoice, { totals: snapshot.totals, user })
 
-        const orderRecord = invoiceResponse?.order ?? {
-          id: resolvedInvoice?.id ?? paymentIntentResult?.id,
-          number: resolvedInvoice?.number ?? resolvedInvoice?.id,
-          status: resolvedInvoice?.status ?? paymentIntentResult?.status ?? 'SUCCEEDED',
-          total: {
-            amount: resolvedInvoice?.totals?.total ?? totals.total,
-            currency: resolvedInvoice?.totals?.currency ?? totals.currency,
-          },
-          customer: resolvedInvoice?.customer ?? {
-            email: user?.email,
-            name: user?.name,
-          },
-          createdAt: resolvedInvoice?.issuedAt ?? new Date().toISOString(),
-        }
+      setActiveInvoice(resolvedInvoice)
+      setInvoices((prev) =>
+        mergeByKey(prev, [resolvedInvoice], (item) => item?.id ?? item?.number),
+      )
 
-        setOrders((prev) => [orderRecord, ...prev])
+      if (orderRecord) {
+        setOrders((prev) =>
+          mergeByKey(prev, [orderRecord], (item) => item?.id ?? item?.number),
+        )
+      }
 
-        if (posApi?.recordOrder) {
+      if (persistenceStatus === HANDOFF_STATUS_SYNCED && posApi?.recordOrder) {
+        try {
           await posApi.recordOrder({
             invoice: resolvedInvoice,
             paymentIntent: paymentIntentResult,
             cart: snapshot,
             user,
           })
+        } catch (error) {
+          persistenceError = persistenceError ?? error
+          persistenceStatus = HANDOFF_STATUS_PENDING
         }
+      }
 
-        clearCart()
-        setPaymentIntent({ id: null, clientSecret: null })
-        setView('invoice')
-        setCheckoutError(null)
-        onInvoiceCreate?.(resolvedInvoice)
-        onOrderComplete?.({
-          invoice: resolvedInvoice,
-          paymentIntent: paymentIntentResult,
-          order: orderRecord,
-          context,
+      if (supportsHandoffs && handoffStorage?.set) {
+        updateHandoffs((current) => {
+          const filtered = current.filter(
+            (entry) =>
+              entry.id !== resolvedInvoice.id &&
+              entry.paymentIntentId !== (paymentIntentResult?.id ?? entry.paymentIntentId),
+          )
+          const nextEntry = {
+            id: resolvedInvoice?.id ?? paymentIntentResult?.id ?? createHandoffId(null),
+            createdAt: Date.now(),
+            status: persistenceStatus,
+            invoice: resolvedInvoice,
+            order: orderRecord,
+            cart: snapshot,
+            paymentIntent: paymentIntentResult,
+            paymentIntentId: paymentIntentResult?.id ?? null,
+            user: user
+              ? { id: user.id, name: user.name, email: user.email }
+              : null,
+            metadata: metadataPayload,
+          }
+          return [nextEntry, ...filtered]
         })
+      }
+
+      clearCart()
+      setPaymentIntent({ id: null, clientSecret: null })
+      setView('invoice')
+
+      if (persistenceStatus === HANDOFF_STATUS_SYNCED) {
+        setCheckoutError(null)
+      } else if (persistenceError) {
+        setCheckoutError(persistenceError)
+        onPaymentError?.(persistenceError)
+      }
+
+      onInvoiceCreate?.(resolvedInvoice)
+      onOrderComplete?.({
+        invoice: resolvedInvoice,
+        paymentIntent: paymentIntentResult,
+        order: orderRecord,
+        context,
+      })
+
+      if (persistenceStatus === HANDOFF_STATUS_SYNCED) {
         refreshHistory()
-      } catch (error) {
-        setCheckoutError(error)
-        onPaymentError?.(error)
       }
     },
     [
@@ -335,9 +564,12 @@ const PointOfSaleExperience = ({
       onPaymentError,
       posApi,
       refreshHistory,
+      handoffStorage,
+      supportsHandoffs,
       totals.currency,
       totals.promoCode,
       totals.total,
+      updateHandoffs,
       user,
     ],
   )
@@ -352,16 +584,59 @@ const PointOfSaleExperience = ({
 
   const handleSelectInvoiceFromOrder = useCallback(
     (order) => {
+      if (!order) return
+
       const invoiceMatch = invoices.find(
         (invoice) =>
           invoice.id === order.invoiceId ||
           invoice.number === order.number ||
           invoice.paymentIntentId === order.paymentIntentId,
       )
-      setActiveInvoice(invoiceMatch ?? buildInvoiceFromOrder(order))
-      setView('invoice')
+
+      if (invoiceMatch) {
+        setActiveInvoice(invoiceMatch)
+        setView('invoice')
+        return
+      }
+
+      const fallbackInvoice = buildInvoiceFromOrder(order)
+
+      const invoiceId =
+        order.invoiceId ?? order.invoice_id ?? order.number ?? order.id ?? order.paymentIntentId
+
+      if (!posApi?.getInvoice || !invoiceId) {
+        setActiveInvoice(fallbackInvoice)
+        setView('invoice')
+        return
+      }
+
+      setIsLoadingInvoices(true)
+
+      posApi
+        .getInvoice({ id: invoiceId })
+        .then((fetchedInvoice) => {
+          const resolved = fetchedInvoice ?? fallbackInvoice
+          if (resolved) {
+            setActiveInvoice(resolved)
+            setInvoices((prev) => {
+              const exists = prev.some((entry) => entry?.id === resolved.id)
+              return exists ? prev : [resolved, ...prev]
+            })
+          } else {
+            setActiveInvoice(fallbackInvoice)
+          }
+        })
+        .catch((error) => {
+          console.error('Failed to fetch invoice details', error)
+          setActiveInvoice(fallbackInvoice)
+        })
+        .finally(() => {
+          setIsLoadingInvoices(false)
+          setView('invoice')
+        })
+
     },
-    [invoices],
+    [invoices, posApi],
   )
 
   const profileContext = useMemo(
@@ -375,6 +650,91 @@ const PointOfSaleExperience = ({
     }),
     [logout, setStripeCustomerId, updateProfile, user, userLoading, userStatus],
   )
+
+  useEffect(() => {
+    if (!supportsHandoffs || !posApi?.createInvoice) return
+    const pending = handoffs.filter((entry) => entry.status === HANDOFF_STATUS_PENDING)
+    if (pending.length === 0) return
+
+    let cancelled = false
+
+    const syncPending = async () => {
+      for (const entry of pending) {
+        if (cancelled) return
+        const paymentIntentPayload =
+          entry.paymentIntent ??
+          (entry.paymentIntentId ? { id: entry.paymentIntentId } : null)
+        const userSnapshot = entry.user ?? user
+        try {
+          const invoiceResponse = await posApi.createInvoice({
+            cart: entry.cart,
+            paymentIntent: paymentIntentPayload,
+            user: userSnapshot,
+            metadata: entry.metadata,
+          })
+
+          if (cancelled) return
+
+          const resolvedInvoice =
+            invoiceResponse?.invoice ?? invoiceResponse ?? entry.invoice ?? null
+          const orderRecord =
+            invoiceResponse?.order ??
+            entry.order ??
+            buildOrderFromInvoice(resolvedInvoice, {
+              totals: entry.cart?.totals ?? totals,
+              user: userSnapshot,
+            })
+
+          if (posApi.recordOrder && resolvedInvoice) {
+            try {
+              await posApi.recordOrder({
+                invoice: resolvedInvoice,
+                paymentIntent: paymentIntentPayload,
+                cart: entry.cart,
+                user: userSnapshot,
+              })
+            } catch (orderError) {
+              console.error('Failed to sync offline order record', orderError)
+            }
+          }
+
+          updateHandoffs((current) =>
+            current.map((handoff) =>
+              handoff.id === entry.id
+                ? {
+                    ...handoff,
+                    status: HANDOFF_STATUS_SYNCED,
+                    invoice: resolvedInvoice ?? handoff.invoice,
+                    order: orderRecord ?? handoff.order,
+                  }
+                : handoff,
+            ),
+          )
+
+          if (resolvedInvoice) {
+            setInvoices((prev) =>
+              mergeByKey(prev, [resolvedInvoice], (item) => item?.id ?? item?.number),
+            )
+          }
+
+          if (orderRecord) {
+            setOrders((prev) =>
+              mergeByKey(prev, [orderRecord], (item) => item?.id ?? item?.number),
+            )
+          }
+        } catch (error) {
+          if (cancelled) return
+          console.error('Failed to sync POS handoff', error)
+        }
+      }
+    }
+
+    syncPending()
+
+    return () => {
+      cancelled = true
+    }
+  }, [handoffs, posApi, supportsHandoffs, totals, updateHandoffs, user])
 
   const profileNode = useMemo(() => {
     if (renderProfile) {

--- a/@guidogerb/components/point-of-sale/src/__tests__/PointOfSale.test.jsx
+++ b/@guidogerb/components/point-of-sale/src/__tests__/PointOfSale.test.jsx
@@ -35,6 +35,28 @@ vi.mock('@stripe/stripe-js', () => ({
 import { Elements } from '@stripe/react-stripe-js'
 import { PointOfSale } from '../PointOfSale.jsx'
 
+const createMockStorage = () => {
+  const store = new Map()
+  const listeners = new Set()
+
+  return {
+    namespace: 'test',
+    get: vi.fn((key, fallback) => (store.has(key) ? store.get(key) : fallback)),
+    set: vi.fn((key, value) => {
+      store.set(key, value)
+      listeners.forEach((listener) => listener({ type: 'set', key, value, namespace: 'test' }))
+      return value
+    }),
+    subscribe: vi.fn((listener) => {
+      listeners.add(listener)
+      return () => {
+        listeners.delete(listener)
+      }
+    }),
+    snapshot: () => Object.fromEntries(store.entries()),
+  }
+}
+
 describe('PointOfSale', () => {
   it('renders catalog, processes payment, and shows invoice + history', async () => {
     const invoiceStore = []
@@ -152,5 +174,270 @@ describe('PointOfSale', () => {
 
     expect(screen.getByText(/Your cart is empty/i)).toBeInTheDocument()
     expect(mockApi.recordOrder).toHaveBeenCalled()
+  })
+
+  it('fetches invoice details when order is selected without local cache', async () => {
+    const mockApi = {
+      listProducts: vi.fn().mockResolvedValue([]),
+      listInvoices: vi.fn().mockResolvedValue([]),
+      listOrders: vi.fn().mockResolvedValue([
+        {
+          id: 'order-200',
+          number: 'INV-200',
+          status: 'PAID',
+          customer: { email: 'customer@example.com' },
+          total: { amount: 4200, currency: 'USD' },
+          createdAt: '2024-02-02T00:00:00.000Z',
+          invoiceId: 'inv_200',
+        },
+      ]),
+      createPaymentIntent: vi.fn(),
+      getInvoice: vi.fn().mockResolvedValue({
+        id: 'inv_200',
+        number: 'INV-200',
+        status: 'PAID',
+        issuedAt: '2024-02-02T00:00:00.000Z',
+        customer: { name: 'Grace Hopper', email: 'customer@example.com' },
+        items: [
+          {
+            id: 'prod-1',
+            name: 'Cloud Seat',
+            quantity: 1,
+            unitPrice: { amount: 4200, currency: 'USD' },
+            total: { amount: 4200, currency: 'USD' },
+          },
+        ],
+        totals: {
+          subtotal: 4200,
+          tax: 0,
+          discount: 0,
+          total: 4200,
+          currency: 'USD',
+        },
+      }),
+    }
+
+    const user = userEvent.setup()
+
+    render(
+      <PointOfSale
+        withElements={false}
+        api={mockApi}
+        initialUser={{ id: 'user-42', name: 'Grace Hopper', email: 'customer@example.com' }}
+      />,
+    )
+
+    await waitFor(() => expect(mockApi.listOrders).toHaveBeenCalledTimes(1))
+
+    const historyButton = await screen.findByRole('button', { name: /order history/i })
+    await user.click(historyButton)
+
+    const viewInvoiceButton = await screen.findByRole('button', { name: /view invoice/i })
+    await user.click(viewInvoiceButton)
+
+    await waitFor(() => expect(mockApi.getInvoice).toHaveBeenCalledWith({ id: 'inv_200' }))
+
+    expect(await screen.findByRole('heading', { name: /Invoice #INV-200/i })).toBeInTheDocument()
+    expect(screen.getByText('Grace Hopper')).toBeInTheDocument()
+  })
+
+  it('persists handoff entries after successful checkout', async () => {
+    const storage = createMockStorage()
+    const invoiceStore = []
+    const orderStore = []
+
+    const mockApi = {
+      listProducts: vi.fn().mockResolvedValue([
+        {
+          id: 'prod-2',
+          title: 'Digital Lesson',
+          description: 'Remote session',
+          price: { amount: 7500, currency: 'USD' },
+          availability: { status: 'AVAILABLE', fulfillment: 'DIGITAL' },
+        },
+      ]),
+      createPaymentIntent: vi.fn().mockResolvedValue({ id: 'pi_456', clientSecret: 'cs_test_456' }),
+      createInvoice: vi.fn().mockImplementation(({ cart, paymentIntent, user }) => {
+        const invoice = {
+          id: 'inv_200',
+          number: 'INV-200',
+          status: 'PAID',
+          issuedAt: '2024-05-01T00:00:00.000Z',
+          customer: { name: user?.name, email: user?.email },
+          items: cart.items,
+          totals: cart.totals,
+        }
+        const order = {
+          id: 'order-200',
+          number: invoice.number,
+          status: invoice.status,
+          customer: invoice.customer,
+          total: { amount: invoice.totals.total, currency: invoice.totals.currency },
+          createdAt: invoice.issuedAt,
+        }
+        invoiceStore.unshift(invoice)
+        orderStore.unshift(order)
+        return Promise.resolve({ invoice, order })
+      }),
+      listInvoices: vi.fn().mockImplementation(() => Promise.resolve([...invoiceStore])),
+      listOrders: vi.fn().mockImplementation(() => Promise.resolve([...orderStore])),
+      recordOrder: vi.fn().mockResolvedValue({}),
+    }
+
+    const mockConfirmPayment = vi.fn().mockResolvedValue({
+      paymentIntent: { id: 'pi_456', status: 'succeeded', client_secret: 'cs_test_456' },
+    })
+
+    const user = userEvent.setup()
+
+    render(
+      <Elements stripe={{}}>
+        <PointOfSale
+          withElements={false}
+          api={mockApi}
+          confirmPayment={mockConfirmPayment}
+          initialUser={{ id: 'user-2', name: 'Nina Simone', email: 'nina@example.com' }}
+          handoffStorage={storage}
+        />
+      </Elements>,
+    )
+
+    const addButton = await screen.findByRole('button', { name: /add to cart/i })
+    await user.click(addButton)
+
+    await waitFor(() => expect(mockApi.createPaymentIntent).toHaveBeenCalled())
+
+    const confirmButton = await screen.findByRole('button', { name: /confirm payment/i })
+    await waitFor(() => expect(confirmButton).not.toBeDisabled())
+    await user.click(confirmButton)
+
+    await waitFor(() => expect(mockConfirmPayment).toHaveBeenCalled())
+    await waitFor(() => expect(mockApi.createInvoice).toHaveBeenCalled())
+
+    expect(await screen.findByText(/Invoice #INV-200/i)).toBeInTheDocument()
+
+    const lastPersistCall = storage.set.mock.calls[storage.set.mock.calls.length - 1]
+    const [, persisted] = lastPersistCall
+    expect(Array.isArray(persisted)).toBe(true)
+    expect(persisted[0]).toMatchObject({
+      status: 'synced',
+      invoice: expect.objectContaining({ id: 'inv_200' }),
+      order: expect.objectContaining({ id: 'order-200' }),
+    })
+  })
+
+  it('queues pending handoffs when invoice persistence fails', async () => {
+    const storage = createMockStorage()
+    const mockApi = {
+      listProducts: vi.fn().mockResolvedValue([
+        {
+          id: 'prod-3',
+          title: 'Workshop Ticket',
+          description: 'Limited seats',
+          price: { amount: 15000, currency: 'USD' },
+          availability: { status: 'AVAILABLE', fulfillment: 'EVENT' },
+        },
+      ]),
+      createPaymentIntent: vi.fn().mockResolvedValue({ id: 'pi_789', clientSecret: 'cs_test_789' }),
+      createInvoice: vi.fn().mockRejectedValue(new Error('offline')), 
+      listInvoices: vi.fn().mockResolvedValue([]),
+      listOrders: vi.fn().mockResolvedValue([]),
+      recordOrder: vi.fn(),
+    }
+
+    const mockConfirmPayment = vi.fn().mockResolvedValue({
+      paymentIntent: { id: 'pi_789', status: 'succeeded', client_secret: 'cs_test_789' },
+    })
+
+    const user = userEvent.setup()
+
+    render(
+      <Elements stripe={{}}>
+        <PointOfSale
+          withElements={false}
+          api={mockApi}
+          confirmPayment={mockConfirmPayment}
+          initialUser={{ id: 'user-3', name: 'Ella Fitzgerald', email: 'ella@example.com' }}
+          handoffStorage={storage}
+        />
+      </Elements>,
+    )
+
+    const addButton = await screen.findByRole('button', { name: /add to cart/i })
+    await user.click(addButton)
+
+    await waitFor(() => expect(mockApi.createPaymentIntent).toHaveBeenCalled())
+
+    const confirmButton = await screen.findByRole('button', { name: /confirm payment/i })
+    await waitFor(() => expect(confirmButton).not.toBeDisabled())
+    await user.click(confirmButton)
+
+    await waitFor(() => expect(mockConfirmPayment).toHaveBeenCalled())
+    await waitFor(() => expect(mockApi.createInvoice).toHaveBeenCalled())
+
+    expect(await screen.findByText(/Invoice #pi_789/i)).toBeInTheDocument()
+
+    const lastPersistedCall = storage.set.mock.calls[storage.set.mock.calls.length - 1]
+    const [, persisted] = lastPersistedCall
+    expect(persisted[0]).toMatchObject({ status: 'pending' })
+  })
+
+  it('hydrates invoices from stored handoffs on mount', async () => {
+    const storage = createMockStorage()
+    const offlineInvoice = {
+      id: 'inv_offline',
+      number: 'INV-OFFLINE',
+      status: 'PENDING',
+      issuedAt: '2024-06-01T12:00:00.000Z',
+      customer: { name: 'Offline User', email: 'offline@example.com' },
+      items: [
+        {
+          id: 'prod-offline',
+          name: 'Offline Bundle',
+          quantity: 1,
+          unitPrice: { amount: 9900, currency: 'USD' },
+          total: { amount: 9900, currency: 'USD' },
+        },
+      ],
+      totals: { subtotal: 9900, tax: 0, discount: 0, total: 9900, currency: 'USD' },
+    }
+
+    storage.set('guidogerb.pos.handoffs', [
+      {
+        id: 'handoff-offline',
+        status: 'pending',
+        invoice: offlineInvoice,
+        order: {
+          id: 'order-offline',
+          number: offlineInvoice.number,
+          status: offlineInvoice.status,
+          customer: offlineInvoice.customer,
+          total: { amount: offlineInvoice.totals.total, currency: offlineInvoice.totals.currency },
+          createdAt: offlineInvoice.issuedAt,
+        },
+        cart: { items: offlineInvoice.items, totals: offlineInvoice.totals },
+      },
+    ])
+
+    const mockApi = {
+      listProducts: vi.fn().mockResolvedValue([]),
+      listInvoices: vi.fn().mockResolvedValue([]),
+      listOrders: vi.fn().mockResolvedValue([]),
+    }
+
+    render(
+      <PointOfSale
+        withElements={false}
+        api={mockApi}
+        initialUser={{ id: 'user-4', name: 'Louis Armstrong', email: 'louis@example.com' }}
+        handoffStorage={storage}
+      />,
+    )
+
+    const invoicesButton = await screen.findByRole('button', { name: /invoices/i })
+    await userEvent.click(invoicesButton)
+
+    expect(await screen.findByText(/Invoice #INV-OFFLINE/i)).toBeInTheDocument()
+    expect(screen.getByText('Offline User')).toBeInTheDocument()
   })
 })

--- a/@guidogerb/components/point-of-sale/src/services/api.js
+++ b/@guidogerb/components/point-of-sale/src/services/api.js
@@ -105,6 +105,17 @@ export function createPOSApi({ baseUrl, client } = {}) {
     })
   }
 
+  const getInvoice = async ({ id }) => {
+    if (!id) {
+      throw new Error('getInvoice requires an id')
+    }
+
+    const response = await resolvedClient.get(`/pos/invoices/${encodeURIComponent(id)}`)
+
+    if (response?.invoice) return response.invoice
+    return response
+  }
+
   const listInvoices = async ({ userId, status } = {}) => {
     const response = await resolvedClient.get(`/pos/invoices${toQuery({ userId, status })}`)
     return Array.isArray(response?.invoices) ? response.invoices : response
@@ -135,6 +146,7 @@ export function createPOSApi({ baseUrl, client } = {}) {
     createPaymentIntent,
     createInvoice,
     listInvoices,
+    getInvoice,
     listOrders,
     recordOrder,
     updateCustomer,

--- a/@guidogerb/components/point-of-sale/tasks.md
+++ b/@guidogerb/components/point-of-sale/tasks.md
@@ -3,5 +3,5 @@
 | name                                   | createdDate | lastUpdatedDate | completedDate | status      | description                                                                                                 |
 | -------------------------------------- | ----------- | --------------- | ------------- | ----------- | ----------------------------------------------------------------------------------------------------------- |
 | Document POS feature surface           | 2025-09-19  | 2025-09-19      | 2025-09-19    | complete    | Summarized catalog integration, Stripe requirements, and service helpers in the README.                     |
-| Wire invoice persistence API           | 2025-09-19  | 2025-09-19      | -             | in progress | Connect the checkout flow to backend endpoints that create invoices and refresh history views.              |
-| Explore offline-friendly cart handoffs | 2025-09-19  | 2025-09-19      | -             | todo        | Investigate caching strategies so carts and invoices survive temporary network loss in retail environments. |
+| Wire invoice persistence API           | 2025-09-19  | 2025-09-21      | 2025-09-21    | complete    | Connect the checkout flow to backend endpoints that create invoices and refresh history views.              |
+| Explore offline-friendly cart handoffs | 2025-09-19  | 2025-09-21      | 2025-09-21    | complete    | Investigate caching strategies so carts and invoices survive temporary network loss in retail environments. |

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -199,6 +199,9 @@ importers:
 
   '@guidogerb/components/point-of-sale':
     dependencies:
+      '@guidogerb/components-analytics':
+        specifier: workspace:*
+        version: link:../analytics
       '@guidogerb/components-catalog':
         specifier: workspace:*
         version: link:../catalog


### PR DESCRIPTION
## Summary
- add a `getInvoice` helper to the point-of-sale API client and export the method
- teach `PointOfSale` to fetch invoice details on demand and to persist cart/invoice handoffs offline with resync logic
- extend the Vitest suite to cover invoice fetching, offline persistence, and hydration flows and declare the analytics dependency

## Testing
- pnpm --filter @guidogerb/components-point-of-sale test

------
https://chatgpt.com/codex/tasks/task_e_68cffd176a348324adab316ffe7a51b4