### PR TITLE
feat(app): implement AppBasic scaffold and strengthen tests

### DIFF
--- a/@guidogerb/components/app/README.md
+++ b/@guidogerb/components/app/README.md
@@ -26,12 +26,13 @@ that truly differ per tenant:
 | `@guidogerb/components-ui`               | Wrap the app in the design system provider and expose shared layout primitives so tokens, typography, and chrome match the Guidogerb brand. | `themeOverrides` plus slot props for header/footer overrides.                   |
 | `@guidogerb/components-router-public`    | Provide the canonical public router instance so marketing URLs resolve consistently.                                                        | `publicRoutes` prop to register tenant-specific routes.                         |
 | `@guidogerb/components-router-protected` | Supply the protected router configured with authentication guards.                                                                          | `protectedRoutes`, optional breadcrumb metadata.                                |
-| `@guidogerb/components-sw`               | Register the standard service worker (`/sw.js`) so offline caching is immediately available.                                                | `serviceWorkerUrl` when a tenant self-hosts an alternate worker.                |
-| `@guidogerb/components-storage`          | Create a storage namespace (`guidogerb.app`) used by auth and feature flags.                                                                | `storagePrefix` for white-label deployments.                                    |
+| `@guidogerb/components-sw`               | Register the standard service worker (`/sw.js`) so offline caching is immediately available.                                                | `serviceWorker` prop forwards custom registration options.                |
+| `@guidogerb/components-storage`          | Create a storage namespace (`guidogerb.app`) used by auth and feature flags.                                                                | `storage` props configure alternate namespaces and persistence.                                    |
 
-Until the providers above are fully wired, `<AppBasic />` renders a placeholder wrapper. The unit
-suite already includes a "renders without crashing" smoke test so we can replace the internals with
-confidence once the wiring lands.
+`<AppBasic />` now composes the provider stack, shared marketing landing, protected router, and
+chrome so tenant projects can render both public and authenticated routes without manual wiring.
+Override navigation, header, footer, authentication, API client, storage, service worker, theming,
+and page collections through the component props.
 
 ## Testing
 
@@ -41,7 +42,5 @@ Run the Vitest suite directly from this package while the workspace manifest is 
 pnpm --dir @guidogerb/components/app test
 ```
 
-## Status
-
-Work-in-progress. The [tasks plan](./tasks.md) tracks detailed milestones for delivering the
-composition described above and for adding additional variants beyond `<AppBasic />`.
+The test suite mocks dependent providers to assert routing, authentication, service worker, and
+storage wiring. Refer to the [tasks plan](./tasks.md) for upcoming variant work.

--- a/@guidogerb/components/app/src/__tests__/App.test.jsx
+++ b/@guidogerb/components/app/src/__tests__/App.test.jsx
@@ -1,4 +1,5 @@
-import { cleanup, render, screen } from '@testing-library/react'
+import { cleanup, render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { describe, expect, it, beforeEach, vi } from 'vitest'
 import { AppBasic, useAppApiClient } from '../App.jsx'
 
@@ -17,6 +18,11 @@ const mocks = vi.hoisted(() => {
     useAuth: vi.fn(() => ({ isAuthenticated: true })),
     registerSW: vi.fn(),
     createClient: vi.fn(() => ({ id: 'generated-client' })),
+    protectedRouter: vi.fn(),
+    storage: vi.fn(),
+    headerProvider: vi.fn(),
+    header: vi.fn(),
+    footer: vi.fn(),
   }
 })
 
@@ -41,6 +47,65 @@ vi.mock('@guidogerb/components-sw', () => ({
   unregisterSW: vi.fn(),
 }))
 
+vi.mock('@guidogerb/components-router-protected', async () => {
+  const actual = await vi.importActual('@guidogerb/components-router-protected')
+  return {
+    __esModule: true,
+    ...actual,
+    ProtectedRouter: vi.fn((props) => {
+      mocks.protectedRouter(props)
+      return actual.ProtectedRouter(props)
+    }),
+  }
+})
+
+vi.mock('@guidogerb/components-storage', async () => {
+  const actual = await vi.importActual('@guidogerb/components-storage')
+  const WrappedStorage = (props) => {
+    mocks.storage(props)
+    return actual.Storage(props)
+  }
+  return {
+    __esModule: true,
+    ...actual,
+    Storage: WrappedStorage,
+    default: WrappedStorage,
+  }
+})
+
+vi.mock('@guidogerb/header', async () => {
+  const actual = await vi.importActual('@guidogerb/header')
+  const HeaderContextProvider = (props) => {
+    mocks.headerProvider(props)
+    return actual.HeaderContextProvider(props)
+  }
+  const Header = (props) => {
+    mocks.header(props)
+    return actual.Header(props)
+  }
+  return {
+    __esModule: true,
+    ...actual,
+    HeaderContextProvider,
+    Header,
+    default: HeaderContextProvider,
+  }
+})
+
+vi.mock('@guidogerb/footer', async () => {
+  const actual = await vi.importActual('@guidogerb/footer')
+  const Footer = (props) => {
+    mocks.footer(props)
+    return actual.Footer(props)
+  }
+  return {
+    __esModule: true,
+    ...actual,
+    Footer,
+    default: Footer,
+  }
+})
+
 describe('AppBasic', () => {
   beforeEach(() => {
     mocks.authProvider.mockClear()
@@ -48,6 +113,11 @@ describe('AppBasic', () => {
     mocks.useAuth.mockReturnValue({ isAuthenticated: true })
     mocks.registerSW.mockClear()
     mocks.createClient.mockClear()
+    mocks.protectedRouter.mockClear()
+    mocks.storage.mockClear()
+    mocks.headerProvider.mockClear()
+    mocks.header.mockClear()
+    mocks.footer.mockClear()
     window.history.replaceState({}, '', '/')
   })
 
@@ -170,5 +240,144 @@ describe('AppBasic', () => {
   it('does not register the service worker when disabled', async () => {
     render(<AppBasic serviceWorker={{ enabled: false }} />)
     expect(mocks.registerSW).not.toHaveBeenCalled()
+  })
+
+  it('forwards custom service worker options when provided', async () => {
+    render(
+      <AppBasic serviceWorker={{ url: '/tenant/sw.js', immediate: true, scope: '/tenant', onOfflineReady: vi.fn() }} />,
+    )
+
+    await waitFor(() => {
+      expect(mocks.registerSW).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: '/tenant/sw.js',
+          immediate: true,
+          scope: '/tenant',
+        }),
+      )
+    })
+  })
+
+  it('invokes navigation handlers from the marketing shell preview', async () => {
+    const user = userEvent.setup()
+    const handleNavigate = vi.fn()
+
+    render(<AppBasic navigation={{ onNavigate: handleNavigate }} />)
+
+    const previewNav = await screen.findByRole('navigation', { name: /app navigation/i })
+    const dashboardLink = within(previewNav).getByRole('link', { name: /dashboard/i })
+
+    expect(within(previewNav).getByRole('link', { name: /welcome/i })).toHaveAttribute('aria-current', 'page')
+
+    await user.click(dashboardLink)
+
+    expect(handleNavigate).toHaveBeenCalledTimes(1)
+    expect(handleNavigate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        item: expect.objectContaining({ id: 'dashboard', href: '/dashboard' }),
+      }),
+    )
+  })
+
+  it('wires route definitions and guard metadata into the protected router', async () => {
+    function Reports() {
+      return <div>Reports</div>
+    }
+
+    function About() {
+      return <div>About Guidogerb</div>
+    }
+
+    window.history.replaceState({}, '', '/app-shell/')
+
+    render(
+      <AppBasic
+        publicPages={{
+          routes: [{ path: '/about', Component: About }],
+          fallback: { element: <div>Public fallback</div> },
+        }}
+        protectedPages={{
+          basename: '/app-shell',
+          routes: [
+            {
+              path: '/reports',
+              Component: Reports,
+              guard: { props: { fallback: <div>Guard loading</div> } },
+            },
+          ],
+          fallback: { element: <div>Missing page</div>, isProtected: true },
+          protectFallback: true,
+          routerOptions: { future: { v7_normalizeFormMethod: true } },
+        }}
+      />,
+    )
+
+    await waitFor(() => expect(mocks.protectedRouter).toHaveBeenCalled())
+
+    const routerProps = mocks.protectedRouter.mock.calls.at(-1)?.[0] ?? {}
+
+    expect(routerProps.routes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ path: '/', isProtected: false }),
+        expect.objectContaining({ path: '/about', isProtected: false }),
+        expect.objectContaining({ path: '/dashboard', isProtected: true }),
+        expect.objectContaining({ path: '/reports', isProtected: true }),
+      ]),
+    )
+
+    expect(routerProps.fallback).toEqual(
+      expect.objectContaining({ path: '*', isFallback: true }),
+    )
+    const expectedLogout = `${window.location.origin}/auth/logout`
+    expect(routerProps.guardProps).toEqual(
+      expect.objectContaining({ logoutUri: expectedLogout }),
+    )
+    expect(routerProps.protectFallback).toBe(true)
+    expect(routerProps.basename).toBe('/app-shell')
+    expect(routerProps.routerOptions).toEqual({ future: { v7_normalizeFormMethod: true } })
+  })
+
+  it('applies navigation overrides to header and footer components', () => {
+    const handleNavigate = vi.fn()
+    const navItems = [
+      { id: 'home', label: 'Home', href: '/' },
+      { id: 'account', label: 'Account', href: '/account' },
+    ]
+
+    render(
+      <AppBasic navigation={{ items: navItems, activePath: '/account', onNavigate: handleNavigate }} />,
+    )
+
+    const providerProps = mocks.headerProvider.mock.calls.at(-1)?.[0] ?? {}
+    expect(providerProps.defaultSettings?.primaryLinks).toHaveLength(navItems.length)
+    expect(providerProps.defaultSettings?.primaryLinks).toEqual(
+      expect.arrayContaining(navItems.map((item) => expect.objectContaining(item))),
+    )
+
+    const headerProps = mocks.header.mock.calls.at(-1)?.[0] ?? {}
+    expect(headerProps.activePath).toBe('/account')
+    expect(headerProps.onNavigate).toBe(handleNavigate)
+
+    const footerProps = mocks.footer.mock.calls.at(-1)?.[0] ?? {}
+    expect(footerProps.onNavigate).toBe(handleNavigate)
+  })
+
+  it('configures storage namespace and forwards persistence props', () => {
+    render(<AppBasic />)
+
+    const defaultStorageProps = mocks.storage.mock.calls.at(-1)?.[0] ?? {}
+    expect(defaultStorageProps.namespace).toBe('guidogerb.app')
+
+    cleanup()
+    mocks.storage.mockClear()
+
+    render(
+      <AppBasic storage={{ namespace: 'tenant.app', mode: 'session', persist: false }} />,
+    )
+
+    const storageProps = mocks.storage.mock.calls.at(-1)?.[0] ?? {}
+    expect(storageProps.namespace).toBe('tenant.app')
+    expect(storageProps.mode).toBe('session')
+    expect(storageProps.persist).toBe(false)
   })
 })

--- a/@guidogerb/components/app/tasks.md
+++ b/@guidogerb/components/app/tasks.md
@@ -10,8 +10,8 @@ pre-configured Guidogerb experience without re-implementing provider wiring.
 | Capture placeholder scope in README     | 2025-09-19  | 2025-09-21      | 2025-09-19    | complete    | Documented that the package currently exports a stub while long-term variants are prepared.                                     |
 | Design shared app shell structure       | 2025-09-19  | 2025-09-21      | -             | in-progress | Finalise the provider order, layout regions, and dependency contracts that every variant must honour.                           |
 | Blueprint `<AppBasic />` provider stack | 2025-09-21  | 2025-09-21      | -             | in-progress | Specify default values and tenant-provided props for the base variant so router, auth, API, and UI layers interoperate.         |
-| Scaffold `<AppBasic />` component       | 2025-09-21  | 2025-09-21      | -             | todo        | Implement the React component that composes all required providers and renders public/protected routes plus shared chrome.      |
-| Harden `<AppBasic />` smoke tests       | 2025-09-21  | 2025-09-21      | -             | todo        | Extend the current render-only test suite with mocked providers to guard against regression in routing, auth, and data loading. |
+| Scaffold `<AppBasic />` component       | 2025-09-21  | 2025-09-21      | 2025-09-21    | complete    | Implement the React component that composes all required providers and renders public/protected routes plus shared chrome.      |
+| Harden `<AppBasic />` smoke tests       | 2025-09-21  | 2025-09-21      | 2025-09-21    | complete    | Extend the current render-only test suite with mocked providers to guard against regression in routing, auth, and data loading. |
 | Add future variant specs                | 2025-09-21  | 2025-09-21      | -             | backlog     | Capture follow-up variants (e.g., analytics-heavy, commerce) after the basic template lands.                                    |
 
 ## `<AppBasic />` implementation notes
@@ -39,5 +39,5 @@ pre-configured Guidogerb experience without re-implementing provider wiring.
 - **`@guidogerb/components-ui` widgets** — provide baseline layout wrappers (header, footer, page
   sections) so tenants only slot in copy, imagery, or feature components.
 
-The initial component keeps rendering a simple placeholder until the tasks above land. The smoke test
-ensures we can replace the internals without breaking consumers.
+`<AppBasic />` now renders the composed provider stack, marketing landing, and protected routes.
+The expanded test suite guards provider wiring so future variants can build on a stable baseline.


### PR DESCRIPTION
## Summary
- expand AppBasic to forward navigation context to the marketing shell and expose service worker registration options
- update the AppBasic documentation and tasks to reflect the completed scaffold
- harden the AppBasic test suite with provider mocks that verify routing, storage, header, and footer wiring

## Testing
- pnpm --dir @guidogerb/components/app test

------
https://chatgpt.com/codex/tasks/task_e_68d04dc5439c832494b46ee439704d97