### PR TITLE
Add analytics referrer tracking and catalog stories

### DIFF
--- a/@guidogerb/components/analytics/README.md
+++ b/@guidogerb/components/analytics/README.md
@@ -84,11 +84,18 @@ function CustomAnalyticsBridge() {
     getParams: ({ location }) => ({
       page_title: `Tenant portal — ${location.pathname}`,
     }),
+    getReferrer: ({ previousPath }) =>
+      previousPath ? `tenant-portal:${previousPath}` : undefined,
   })
 
   return null
 }
 ```
+
+`includeReferrer` is enabled by default so GA4 receives a `page_referrer`
+parameter derived from the last tracked path. Disable it with
+`includeReferrer={false}` or return your own value from `getReferrer` when you
+need to normalise tenant-specific URLs.
 
 ## Component API
 

--- a/@guidogerb/components/catalog/src/__stories__/Catalog.stories.jsx
+++ b/@guidogerb/components/catalog/src/__stories__/Catalog.stories.jsx
@@ -1,0 +1,216 @@
+import { useMemo } from 'react'
+import { Catalog } from '../Catalog.jsx'
+import { createStorageController } from '@guidogerb/components-storage'
+
+const meta = {
+  title: 'Components/Catalog/Catalog',
+  component: Catalog,
+  parameters: {
+    layout: 'fullscreen',
+  },
+}
+
+export default meta
+
+const MOCK_PRODUCTS = [
+  {
+    id: 'digital-mastering',
+    sku: 'DIGI-001',
+    slug: 'mix-mastering',
+    title: 'Mix & Master Subscription',
+    subtitle: 'Unlimited digital mastering',
+    description: 'Monthly plan that delivers polished mixes with 48 hour turnaround.',
+    type: 'SUBSCRIPTION',
+    format: 'Streaming',
+    genres: ['Audio'],
+    tags: ['Featured', 'Studio'],
+    badges: ['Popular'],
+    price: { amount: 9900, currency: 'USD', interval: 'Month' },
+    availability: { status: 'AVAILABLE', fulfillment: 'DIGITAL' },
+    media: [],
+    metadata: { runtime: 'Unlimited' },
+  },
+  {
+    id: 'vinyl-boxset',
+    sku: 'VINYL-900',
+    slug: 'limited-box-set',
+    title: 'Guidogerb Classics Vinyl Box',
+    subtitle: 'Hand numbered pressing',
+    description: 'Seven LP anthology pressed on 180 gram vinyl with archival booklet.',
+    type: 'ALBUM',
+    format: 'Vinyl',
+    genres: ['Jazz'],
+    tags: ['Collector'],
+    badges: ['Limited'],
+    price: { amount: 24900, currency: 'USD' },
+    availability: { status: 'PREORDER', fulfillment: 'PHYSICAL' },
+    media: [],
+    metadata: { discs: 7 },
+  },
+  {
+    id: 'lesson-pack',
+    sku: 'LESSON-030',
+    slug: 'private-lessons',
+    title: 'Private Lesson 3-Pack',
+    subtitle: 'Remote theory deep dive',
+    description: 'Three sixty minute sessions covering improvisation and arrangement.',
+    type: 'SERVICE',
+    format: 'Virtual',
+    genres: ['Education'],
+    tags: ['Mentorship'],
+    badges: ['Staff pick'],
+    price: { amount: 45000, currency: 'USD' },
+    availability: { status: 'AVAILABLE', fulfillment: 'DIGITAL' },
+    media: [],
+    metadata: { lessons: 3 },
+  },
+  {
+    id: 'tour-tee',
+    sku: 'MERCH-007',
+    slug: 'world-tour-shirt',
+    title: 'World Tour T-Shirt',
+    subtitle: 'Soft-touch cotton blend',
+    description: 'Tour artwork on a unisex tee with sustainable packaging.',
+    type: 'MERCH',
+    format: 'Apparel',
+    genres: ['Merch'],
+    tags: ['New'],
+    badges: ['Ships worldwide'],
+    price: { amount: 3500, currency: 'USD' },
+    availability: { status: 'IN_STOCK', fulfillment: 'PHYSICAL' },
+    media: [],
+    metadata: { sizes: ['S', 'M', 'L', 'XL'] },
+  },
+  {
+    id: 'bundle-hybrid',
+    sku: 'BUNDLE-123',
+    slug: 'membership-bundle',
+    title: 'Streaming + Vinyl Bundle',
+    subtitle: 'Access everywhere with limited drops',
+    description: 'Hybrid bundle that includes digital streaming and quarterly vinyl shipments.',
+    type: 'BUNDLE',
+    format: 'Hybrid',
+    genres: ['Hybrid'],
+    tags: ['Bundle'],
+    badges: ['Best value'],
+    price: { amount: 14900, currency: 'USD', interval: 'Month' },
+    availability: { status: 'AVAILABLE', fulfillment: 'HYBRID' },
+    media: [],
+    metadata: { shipmentsPerYear: 4 },
+  },
+]
+
+const INITIAL_PAGES = [
+  {
+    cursor: null,
+    items: MOCK_PRODUCTS.slice(0, 3),
+    pageInfo: { total: MOCK_PRODUCTS.length, hasNextPage: true, endCursor: 'page-2' },
+  },
+  {
+    cursor: 'page-2',
+    items: MOCK_PRODUCTS.slice(3),
+    pageInfo: { total: MOCK_PRODUCTS.length, hasNextPage: false, endCursor: null },
+  },
+]
+
+const filterProducts = (products, variables = {}) => {
+  let filtered = [...products]
+
+  const requestedTypes = variables.filters?.productTypes ?? []
+  const requestedFulfillment = variables.filters?.fulfillment ?? []
+  const searchTerm = variables.search?.toLowerCase?.()
+
+  if (requestedTypes.length) {
+    filtered = filtered.filter((product) => requestedTypes.includes(product.type))
+  }
+
+  if (requestedFulfillment.length) {
+    filtered = filtered.filter((product) => requestedFulfillment.includes(product.availability.fulfillment))
+  }
+
+  if (searchTerm) {
+    filtered = filtered.filter((product) =>
+      [product.title, product.subtitle, product.description]
+        .filter(Boolean)
+        .some((value) => value.toLowerCase().includes(searchTerm)),
+    )
+  }
+
+  return filtered
+}
+
+const createMockClient = () => ({
+  async post(_path, { json }) {
+    const variables = json?.variables ?? {}
+    const hasFilters = Boolean(
+      variables.search ||
+        variables.filters?.productTypes?.length ||
+        variables.filters?.fulfillment?.length,
+    )
+
+    const requestedPage = variables.pagination?.after ?? null
+
+    let items = MOCK_PRODUCTS
+    let pageInfo = { total: MOCK_PRODUCTS.length, hasNextPage: false, endCursor: null }
+
+    if (hasFilters) {
+      items = filterProducts(MOCK_PRODUCTS, variables)
+      pageInfo = { total: items.length, hasNextPage: false, endCursor: null }
+    } else {
+      const page = INITIAL_PAGES.find((entry) => entry.cursor === requestedPage) ?? INITIAL_PAGES[0]
+      items = page.items
+      pageInfo = page.pageInfo
+    }
+
+    return {
+      data: {
+        catalog: {
+          items,
+          pageInfo,
+        },
+      },
+    }
+  },
+})
+
+function CatalogPlayground(props) {
+  const client = useMemo(() => createMockClient(), [])
+  const storage = useMemo(
+    () =>
+      createStorageController({
+        namespace: 'story.catalog',
+        area: 'memory',
+      }),
+    [],
+  )
+
+  return (
+    <Catalog
+      client={client}
+      storage={storage}
+      pageSize={3}
+      graphQLEndpoint="/graphql/catalog"
+      onProductSelect={() => {}}
+      {...props}
+    />
+  )
+}
+
+export { CatalogPlayground }
+
+export const Default = {
+  render: () => <CatalogPlayground />,
+}
+
+export const ListView = {
+  render: () => <CatalogPlayground initialView="list" />,
+}
+
+export const PhysicalFocus = {
+  render: () => (
+    <CatalogPlayground
+      initialFilters={{ fulfillment: ['PHYSICAL'] }}
+      searchPlaceholder="Search catalog for merch"
+    />
+  ),
+}

--- a/@guidogerb/components/catalog/src/__tests__/Catalog.stories.test.jsx
+++ b/@guidogerb/components/catalog/src/__tests__/Catalog.stories.test.jsx
@@ -1,0 +1,46 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+
+import {
+  Default as CatalogDefault,
+  ListView as CatalogListView,
+  PhysicalFocus as CatalogPhysicalFocus,
+} from '../__stories__/Catalog.stories.jsx'
+
+const renderStory = (story) => {
+  if (typeof story === 'function') {
+    return render(story())
+  }
+
+  if (story && typeof story.render === 'function') {
+    return render(story.render())
+  }
+
+  throw new Error('Unsupported story shape')
+}
+
+describe('Catalog stories', () => {
+  it('renders the default catalog playground without crashing', async () => {
+    renderStory(CatalogDefault)
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: /digital delivery/i })).toBeInTheDocument()
+    })
+  })
+
+  it('renders the list view variation', async () => {
+    renderStory(CatalogListView)
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'List' })).toHaveAttribute('data-active', 'true')
+    })
+  })
+
+  it('renders the physical fulfillment focused view', async () => {
+    renderStory(CatalogPhysicalFocus)
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: /physical shipment/i })).toBeInTheDocument()
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- add optional referrer enrichment to the analytics router bridge and document the new hook options
- extend the analytics test suite to cover custom referrer builders and opt-out behaviour
- create a Storybook playground with mocked catalog data and add render smoke tests for each story

## Testing
- pnpm --filter @guidogerb/components-analytics test
- pnpm --filter @guidogerb/components-catalog test
- pnpm -r --workspace-concurrency=1 test *(hangs on @guidogerb/components-ai-support after several minutes, command aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68d0544ec8508324afad00dd25966e4a