### PR TITLE
Add local AWS edge simulation environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,13 @@ corepack prepare pnpm@latest --activate
 pnpm -v
 ```
 
+### Simulated AWS Edge stack
+
+- [`infra/local-dev/README.md`](./infra/local-dev/README.md) describes a Docker
+  compose environment that mimics the production architecture (CloudFront + S3,
+  API Gateway + Lambda, API Gateway + ECS Fargate) with Cognito-style JWT
+  protection for host-based routing during local development.
+
 ## License
 
 GuidoGerb Publishing, LLC distributes this repository under the [Apache License 2.0](./LICENSE).

--- a/infra/local-dev/README.md
+++ b/infra/local-dev/README.md
@@ -1,0 +1,147 @@
+# Local AWS Edge Simulation
+
+This directory provisions a Docker-based sandbox that mirrors the Phase 1
+hosting plan (CloudFront → S3, API Gateway → Lambda, API Gateway → ECS
+Fargate) without touching AWS. The goal is to exercise the multi-tenant
+routing, JWT-protected APIs, and separation between serverless functions and
+container workloads using the same hostnames as production.
+
+## Topology
+
+| Component | Local service | Purpose |
+| --------- | ------------- | ------- |
+| CloudFront | `guidogerb-cloudfront` (Nginx) | Acts as the edge distribution. Routes hostnames to the S3 origin or to the API Gateway container and forwards the `Host` header so per-tenant logic can run downstream. |
+| S3 origin  | `guidogerb-s3` (Nginx) | Serves SPA builds from `infra/local-dev/data/s3/tenants/<host>` with an `_placeholder` fallback when no build has been synced. |
+| Cognito    | `guidogerb-cognito` (FastAPI) | Issues RS256-signed JWT access tokens and exposes a JWKS endpoint. Mimics a Cognito user pool for local sign-in flows. |
+| API Gateway | `guidogerb-api-gateway` (FastAPI) | Validates Cognito JWTs and forwards requests based on the host name: `api.local.<tenant>` → Lambda, `app.local.<tenant>` → Fargate. |
+| Lambda     | `guidogerb-lambda` (FastAPI) | Sample Python handler that echoes requests and includes tenant metadata injected by the API gateway. |
+| ECS Fargate | `guidogerb-fargate` (FastAPI) | Simulated container service with a sample `/orders` API. |
+
+All services share the `guidogerb` Docker network to emulate VPC-internal DNS
+(`*.service.local`).
+
+## Prerequisites
+
+- Docker Desktop or Docker Engine 24+
+- `pnpm` to build website assets that will be copied into the S3 emulation
+- Hostname mappings so the CloudFront container can distinguish each tenant.
+  Append the following to `/etc/hosts` (or the Windows equivalent) as needed:
+
+  ```text
+  127.0.0.1 local.guidogerbpublishing.com
+  127.0.0.1 api.local.guidogerbpublishing.com
+  127.0.0.1 app.local.guidogerbpublishing.com
+  127.0.0.2 local.picklecheeze.com
+  127.0.0.2 api.local.picklecheeze.com
+  127.0.0.2 app.local.picklecheeze.com
+  127.0.0.3 local.stream4cloud.com
+  127.0.0.3 api.local.stream4cloud.com
+  127.0.0.3 app.local.stream4cloud.com
+  127.0.0.4 local.this-is-my-story.org
+  127.0.0.4 api.local.this-is-my-story.org
+  127.0.0.4 app.local.this-is-my-story.org
+  127.0.0.7 local.garygerber.com
+  127.0.0.7 api.local.garygerber.com
+  127.0.0.7 app.local.garygerber.com
+  127.0.0.8 local.ggp.llc
+  127.0.0.8 api.local.ggp.llc
+  127.0.0.8 app.local.ggp.llc
+  ```
+
+  > The IP spread mimics the production CIDR allocations documented in
+  > `README.md`. Browsers will resolve each tenant domain to a unique loopback
+  > IP, allowing `docker-compose` to keep port 8080 free for all sites.
+
+## Usage
+
+1. **Build the sites you want to preview**
+
+   ```bash
+   pnpm -r build
+   # or build individual sites, e.g. pnpm --filter websites-guidogerbpublishing build
+   ```
+
+2. **Sync the artifacts into the simulated S3 buckets**
+
+   ```bash
+   ./infra/local-dev/scripts/sync-sites.sh
+   ```
+
+   The script copies `websites/<tenant>/dist` into
+   `infra/local-dev/data/s3/tenants/local.<tenant>`. When a site has not been
+   built you will see a warning and the CloudFront placeholder page will render
+   instead.
+
+3. **Launch the environment**
+
+   ```bash
+   docker compose -f infra/local-dev/docker-compose.yml up --build
+   ```
+
+   - CloudFront is exposed on `http://local.<tenant>:8080`
+   - Cognito is exposed on `http://localhost:8100` for issuing tokens
+
+4. **Fetch a Cognito JWT**
+
+   ```bash
+   curl -s http://localhost:8100/token \
+     -H 'Content-Type: application/json' \
+     -d '{"username":"guidogerb","audience":"guidogerb-api"}' | jq -r .access_token
+   ```
+
+   Switch `audience` to `guidogerb-app` when calling the Fargate host header
+   (`app.local.<tenant>`). The JWKS lives at
+   `http://localhost:8100/.well-known/jwks.json`.
+
+5. **Call the API Gateway**
+
+   ```bash
+   TOKEN=$(curl -s http://localhost:8100/token -H 'Content-Type: application/json' \
+     -d '{"username":"guidogerb","audience":"guidogerb-api"}' | jq -r .access_token)
+
+   curl -H "Host: api.local.guidogerbpublishing.com" \
+     -H "Authorization: Bearer $TOKEN" \
+     http://localhost:8080/hello | jq
+   ```
+
+   Swap the host for `app.local.guidogerbpublishing.com` and request
+   `/orders` to hit the simulated ECS service:
+
+   ```bash
+   TOKEN=$(curl -s http://localhost:8100/token -H 'Content-Type: application/json' \
+     -d '{"username":"guidogerb","audience":"guidogerb-app"}' | jq -r .access_token)
+
+   curl -H "Host: app.local.guidogerbpublishing.com" \
+     -H "Authorization: Bearer $TOKEN" \
+     http://localhost:8080/orders | jq
+   ```
+
+6. **Stop the stack**
+
+   ```bash
+   docker compose -f infra/local-dev/docker-compose.yml down
+   ```
+
+## Notes & Extensibility
+
+- The FastAPI services keep tokens in memory; restart `docker compose` if you
+  want to rotate the signing key.
+- Override service URLs, audiences, or JWT lifetimes by passing environment
+  variables in `docker-compose.yml` or `docker compose ... --env-file`.
+- The API Gateway forwards arbitrary HTTP methods, so you can test mutation
+  flows (`POST`, `PUT`, `DELETE`) end-to-end. Request bodies are proxied as-is.
+- Extend `infra/local-dev/scripts/sync-sites.sh` with new tenants as they come
+  online. The Nginx maps already include the six initial domains listed in the
+  monorepo README.
+- To experiment with HTTPS locally, wrap the CloudFront container with
+  `mkcert` or place a TLS termination proxy (Caddy/Traefik) in front of it.
+
+## Troubleshooting
+
+- **401 Unauthorized** — ensure the JWT `aud` claim matches the host header
+  (`guidogerb-api` for `api.local.*`, `guidogerb-app` for `app.local.*`).
+- **Placeholder page** — run `pnpm --filter websites-<tenant> build` and rerun
+  the sync script.
+- **JWKS fetch errors** — the API Gateway waits for the Cognito mock to start.
+  If you see repeated JWKS failures, restart the stack so the JWKS cache can
+  refresh.

--- a/infra/local-dev/cloudfront/nginx.conf
+++ b/infra/local-dev/cloudfront/nginx.conf
@@ -1,0 +1,102 @@
+worker_processes  1;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    sendfile        on;
+    keepalive_timeout  65;
+    server_tokens off;
+
+    map $host $tenant_name {
+        default "";
+        local.guidogerbpublishing.com guidogerbpublishing.com;
+        api.local.guidogerbpublishing.com guidogerbpublishing.com;
+        app.local.guidogerbpublishing.com guidogerbpublishing.com;
+        local.picklecheeze.com picklecheeze.com;
+        api.local.picklecheeze.com picklecheeze.com;
+        app.local.picklecheeze.com picklecheeze.com;
+        local.stream4cloud.com stream4cloud.com;
+        api.local.stream4cloud.com stream4cloud.com;
+        app.local.stream4cloud.com stream4cloud.com;
+        local.garygerber.com garygerber.com;
+        api.local.garygerber.com garygerber.com;
+        app.local.garygerber.com garygerber.com;
+        local.ggp.llc ggp.llc;
+        api.local.ggp.llc ggp.llc;
+        app.local.ggp.llc ggp.llc;
+        local.this-is-my-story.org this-is-my-story.org;
+        api.local.this-is-my-story.org this-is-my-story.org;
+        app.local.this-is-my-story.org this-is-my-story.org;
+    }
+
+    upstream s3_origin {
+        server s3-static:8080;
+    }
+
+    upstream api_gateway {
+        server api-gateway:8000;
+    }
+
+    log_format cloudfront '$remote_addr - $host [$time_local] "$request" $status $body_bytes_sent '
+                         '"$http_referer" "$http_user_agent"';
+
+    access_log  /var/log/nginx/access.log cloudfront;
+
+    server {
+        listen       80;
+        server_name  local.guidogerbpublishing.com local.picklecheeze.com local.stream4cloud.com local.garygerber.com local.ggp.llc local.this-is-my-story.org;
+
+        location / {
+            proxy_pass http://s3_origin;
+            proxy_set_header Host $host;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-CloudFront-Tenant $tenant_name;
+            proxy_intercept_errors on;
+        }
+    }
+
+    server {
+        listen       80;
+        server_name  api.local.guidogerbpublishing.com api.local.picklecheeze.com api.local.stream4cloud.com api.local.garygerber.com api.local.ggp.llc api.local.this-is-my-story.org;
+
+        location / {
+            proxy_pass http://api_gateway;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header Connection "";
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-CloudFront-Tenant $tenant_name;
+        }
+    }
+
+    server {
+        listen       80;
+        server_name  app.local.guidogerbpublishing.com app.local.picklecheeze.com app.local.stream4cloud.com app.local.garygerber.com app.local.ggp.llc app.local.this-is-my-story.org;
+
+        location / {
+            proxy_pass http://api_gateway;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header Connection "";
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-CloudFront-Tenant $tenant_name;
+        }
+    }
+
+    server {
+        listen 80 default_server;
+        server_name _;
+        return 404;
+    }
+}

--- a/infra/local-dev/data/s3/.gitignore
+++ b/infra/local-dev/data/s3/.gitignore
@@ -1,0 +1,8 @@
+# Generated tenant content copied from website builds
+/tenants/
+
+# Allow placeholder assets to remain tracked
+!/_placeholder/
+!/_placeholder/index.html
+
+!.gitignore

--- a/infra/local-dev/data/s3/_placeholder/index.html
+++ b/infra/local-dev/data/s3/_placeholder/index.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>GuidoGerb Local CloudFront Simulation</title>
+    <style>
+      body {
+        font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        min-height: 100vh;
+        display: grid;
+        place-items: center;
+        margin: 0;
+        background: linear-gradient(135deg, #1e3c72 0%, #2a5298 100%);
+        color: #fff;
+      }
+      main {
+        background: rgba(0, 0, 0, 0.4);
+        border-radius: 12px;
+        padding: 2.5rem 3rem;
+        max-width: 480px;
+        text-align: center;
+        box-shadow: 0 12px 30px rgba(0, 0, 0, 0.35);
+      }
+      h1 {
+        font-size: 1.75rem;
+        margin-bottom: 1rem;
+      }
+      p {
+        line-height: 1.6;
+        font-size: 1rem;
+      }
+      code {
+        background: rgba(255, 255, 255, 0.15);
+        padding: 0.25rem 0.5rem;
+        border-radius: 6px;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Local CloudFront &amp; S3 Sandbox</h1>
+      <p>
+        This is placeholder content served from the simulated S3 origin. Build a
+        website and run <code>infra/local-dev/scripts/sync-sites.sh</code> to copy
+        tenant assets into <code>infra/local-dev/data/s3/tenants</code>.
+      </p>
+      <p>
+        Requests that land on this page mean the tenant bucket has not been
+        populated yet.
+      </p>
+    </main>
+  </body>
+</html>

--- a/infra/local-dev/docker-compose.yml
+++ b/infra/local-dev/docker-compose.yml
@@ -1,0 +1,77 @@
+version: "3.9"
+
+services:
+  cloudfront:
+    image: nginx:1.27-alpine
+    container_name: guidogerb-cloudfront
+    ports:
+      - "8080:80"
+    volumes:
+      - ./cloudfront/nginx.conf:/etc/nginx/nginx.conf:ro
+    depends_on:
+      - s3-static
+      - api-gateway
+    networks:
+      - guidogerb
+
+  s3-static:
+    image: nginx:1.27-alpine
+    container_name: guidogerb-s3
+    volumes:
+      - ./s3/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./data/s3:/var/www/sites:ro
+    networks:
+      - guidogerb
+
+  cognito-mock:
+    build:
+      context: ./services
+      dockerfile: cognito-mock/Dockerfile
+    container_name: guidogerb-cognito
+    environment:
+      COGNITO_ISSUER: http://cognito-mock:8000
+      COGNITO_DEFAULT_AUDIENCES: guidogerb-api,guidogerb-app
+      COGNITO_APP_CLIENT_ID: local-dev-client
+    ports:
+      - "8100:8000"
+    networks:
+      - guidogerb
+
+  lambda-service:
+    build:
+      context: ./services
+      dockerfile: lambda/Dockerfile
+    container_name: guidogerb-lambda
+    networks:
+      - guidogerb
+
+  fargate-service:
+    build:
+      context: ./services
+      dockerfile: fargate/Dockerfile
+    container_name: guidogerb-fargate
+    networks:
+      - guidogerb
+
+  api-gateway:
+    build:
+      context: ./services
+      dockerfile: api-gateway/Dockerfile
+    container_name: guidogerb-api-gateway
+    environment:
+      COGNITO_JWKS_URL: http://cognito-mock:8000/.well-known/jwks.json
+      COGNITO_ISSUER: http://cognito-mock:8000
+      LAMBDA_URL: http://lambda-service:9000
+      FARGATE_URL: http://fargate-service:9001
+      LAMBDA_AUDIENCE: guidogerb-api
+      FARGATE_AUDIENCE: guidogerb-app
+    depends_on:
+      - cognito-mock
+      - lambda-service
+      - fargate-service
+    networks:
+      - guidogerb
+
+networks:
+  guidogerb:
+    driver: bridge

--- a/infra/local-dev/s3/nginx.conf
+++ b/infra/local-dev/s3/nginx.conf
@@ -1,0 +1,103 @@
+worker_processes  1;
+
+events {
+    worker_connections  512;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    sendfile        on;
+    keepalive_timeout  65;
+    server_tokens off;
+
+    log_format s3 '$remote_addr - $host [$time_local] "$request" $status $body_bytes_sent '
+                   '"$http_referer" "$http_user_agent"';
+
+    access_log  /var/log/nginx/access.log s3;
+
+    server {
+        listen       8080;
+        server_name  local.guidogerbpublishing.com;
+        root         /var/www/sites/tenants/local.guidogerbpublishing.com;
+        index        index.html;
+
+        location / {
+            try_files $uri $uri/ /index.html;
+            add_header X-S3-Simulated-Bucket "local.guidogerbpublishing.com" always;
+        }
+    }
+
+    server {
+        listen       8080;
+        server_name  local.picklecheeze.com;
+        root         /var/www/sites/tenants/local.picklecheeze.com;
+        index        index.html;
+
+        location / {
+            try_files $uri $uri/ /index.html;
+            add_header X-S3-Simulated-Bucket "local.picklecheeze.com" always;
+        }
+    }
+
+    server {
+        listen       8080;
+        server_name  local.stream4cloud.com;
+        root         /var/www/sites/tenants/local.stream4cloud.com;
+        index        index.html;
+
+        location / {
+            try_files $uri $uri/ /index.html;
+            add_header X-S3-Simulated-Bucket "local.stream4cloud.com" always;
+        }
+    }
+
+    server {
+        listen       8080;
+        server_name  local.garygerber.com;
+        root         /var/www/sites/tenants/local.garygerber.com;
+        index        index.html;
+
+        location / {
+            try_files $uri $uri/ /index.html;
+            add_header X-S3-Simulated-Bucket "local.garygerber.com" always;
+        }
+    }
+
+    server {
+        listen       8080;
+        server_name  local.ggp.llc;
+        root         /var/www/sites/tenants/local.ggp.llc;
+        index        index.html;
+
+        location / {
+            try_files $uri $uri/ /index.html;
+            add_header X-S3-Simulated-Bucket "local.ggp.llc" always;
+        }
+    }
+
+    server {
+        listen       8080;
+        server_name  local.this-is-my-story.org;
+        root         /var/www/sites/tenants/local.this-is-my-story.org;
+        index        index.html;
+
+        location / {
+            try_files $uri $uri/ /index.html;
+            add_header X-S3-Simulated-Bucket "local.this-is-my-story.org" always;
+        }
+    }
+
+    server {
+        listen 8080 default_server;
+        server_name _;
+        root /var/www/sites/_placeholder;
+        index index.html;
+
+        location / {
+            try_files $uri $uri/ /index.html;
+            add_header X-S3-Simulated-Bucket "placeholder" always;
+        }
+    }
+}

--- a/infra/local-dev/scripts/sync-sites.sh
+++ b/infra/local-dev/scripts/sync-sites.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DATA_DIR="$ROOT_DIR/infra/local-dev/data/s3/tenants"
+
+SITES=(
+  "guidogerbpublishing.com"
+  "picklecheeze.com"
+  "stream4cloud.com"
+  "garygerber.com"
+  "ggp.llc"
+  "this-is-my-story.org"
+)
+
+workspace_name_for_site() {
+  case "$1" in
+    "guidogerbpublishing.com") echo "websites-guidogerbpublishing" ;;
+    "picklecheeze.com") echo "websites-picklecheeze" ;;
+    "stream4cloud.com") echo "websites-stream4cloud" ;;
+    "garygerber.com") echo "websites-garygerber" ;;
+    "ggp.llc") echo "websites-ggp-llc" ;;
+    "this-is-my-story.org") echo "websites-this-is-my-story" ;;
+    *) return 1 ;;
+  esac
+}
+
+mkdir -p "$DATA_DIR"
+
+for SITE in "${SITES[@]}"; do
+  SRC="$ROOT_DIR/websites/$SITE/dist"
+  DEST="$DATA_DIR/local.$SITE"
+
+  if [[ ! -d "$SRC" ]]; then
+    echo "[warn] build output not found for $SITE at $SRC" >&2
+    if WORKSPACE_NAME=$(workspace_name_for_site "$SITE" 2>/dev/null); then
+      echo "       run 'pnpm --filter $WORKSPACE_NAME build' or 'pnpm -r build' first" >&2
+    else
+      echo "       run 'pnpm -r build' first" >&2
+    fi
+    continue
+  fi
+
+  echo "[sync] copying $SITE"
+  rm -rf "$DEST"
+  mkdir -p "$DEST"
+  cp -R "$SRC"/* "$DEST/"
+done
+
+echo "Done. Updated tenants live under infra/local-dev/data/s3/tenants"

--- a/infra/local-dev/services/api-gateway/Dockerfile
+++ b/infra/local-dev/services/api-gateway/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.12-slim AS base
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential libssl-dev libffi-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
+
+COPY api-gateway/app ./app
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/infra/local-dev/services/api-gateway/app/main.py
+++ b/infra/local-dev/services/api-gateway/app/main.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Dict
+
+import httpx
+import jwt
+from fastapi import FastAPI, HTTPException, Request, Response, status
+from fastapi.responses import JSONResponse
+from jwt import PyJWKClient
+
+app = FastAPI(title="GuidoGerb API Gateway", version="0.1.0")
+
+JWKS_URL = os.getenv("COGNITO_JWKS_URL", "http://cognito-mock:8000/.well-known/jwks.json")
+ISSUER = os.getenv("COGNITO_ISSUER", "http://cognito-mock:8000")
+LAMBDA_URL = os.getenv("LAMBDA_URL", "http://lambda-service:9000")
+FARGATE_URL = os.getenv("FARGATE_URL", "http://fargate-service:9001")
+LAMBDA_AUDIENCE = os.getenv("LAMBDA_AUDIENCE", "guidogerb-api")
+FARGATE_AUDIENCE = os.getenv("FARGATE_AUDIENCE", "guidogerb-app")
+REQUEST_TIMEOUT = float(os.getenv("UPSTREAM_TIMEOUT", "10"))
+
+_jwks_client = PyJWKClient(JWKS_URL)
+
+
+@dataclass
+class BackendContext:
+    tenant: str
+    audience: str
+    base_url: str
+    target: str
+
+
+def resolve_context(host_header: str) -> BackendContext:
+    host = host_header.split(":", 1)[0].lower()
+    if host.startswith("api.local."):
+        tenant = host.removeprefix("api.local.")
+        return BackendContext(tenant=tenant, audience=LAMBDA_AUDIENCE, base_url=LAMBDA_URL, target="lambda")
+    if host.startswith("app.local."):
+        tenant = host.removeprefix("app.local.")
+        return BackendContext(tenant=tenant, audience=FARGATE_AUDIENCE, base_url=FARGATE_URL, target="fargate")
+    raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Unknown API host '{host_header}'")
+
+
+def decode_jwt(token: str, expected_audience: str) -> Dict:
+    try:
+        signing_key = _jwks_client.get_signing_key_from_jwt(token)
+    except Exception as exc:  # pylint: disable=broad-except
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unable to resolve signing key") from exc
+
+    try:
+        return jwt.decode(
+            token,
+            signing_key.key,
+            algorithms=["RS256"],
+            audience=expected_audience,
+            issuer=ISSUER,
+        )
+    except jwt.PyJWTError as exc:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=str(exc)) from exc
+
+
+@app.get("/healthz")
+async def healthz() -> dict:
+    return {
+        "status": "ok",
+        "jwks": JWKS_URL,
+        "lambda_url": LAMBDA_URL,
+        "fargate_url": FARGATE_URL,
+    }
+
+
+@app.api_route("/{path:path}", methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"])
+async def proxy(path: str, request: Request) -> Response:
+    if path == "healthz":
+        return await healthz()
+
+    host_header = request.headers.get("host")
+    if not host_header:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Host header is required")
+
+    context = resolve_context(host_header)
+
+    auth_header = request.headers.get("authorization")
+    if not auth_header or not auth_header.lower().startswith("bearer "):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Bearer token is required")
+
+    token = auth_header.split(" ", 1)[1]
+    claims = decode_jwt(token, context.audience)
+
+    body = await request.body()
+
+    forward_headers = {
+        key: value
+        for key, value in request.headers.items()
+        if key.lower() not in {"host", "content-length", "connection"}
+    }
+    forward_headers.update(
+        {
+            "x-forwarded-host": host_header,
+            "x-guidogerb-tenant": context.tenant,
+            "x-guidogerb-username": claims.get("username") or claims.get("sub", ""),
+            "x-guidogerb-target": context.target,
+        }
+    )
+
+    target_url = f"{context.base_url}{request.url.path}"
+
+    try:
+        async with httpx.AsyncClient(timeout=REQUEST_TIMEOUT) as client:
+            upstream_response = await client.request(
+                request.method,
+                target_url,
+                params=dict(request.query_params),
+                headers=forward_headers,
+                content=body,
+            )
+    except httpx.HTTPError as exc:
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=str(exc)) from exc
+
+    excluded = {"content-length", "connection", "transfer-encoding"}
+    response_headers = {
+        key: value for key, value in upstream_response.headers.items() if key.lower() not in excluded
+    }
+
+    return Response(
+        content=upstream_response.content,
+        status_code=upstream_response.status_code,
+        headers=response_headers,
+        media_type=upstream_response.headers.get("content-type"),
+    )
+
+
+@app.exception_handler(HTTPException)
+async def http_exception_handler(_: Request, exc: HTTPException) -> JSONResponse:
+    headers = exc.headers or {}
+    if exc.status_code == status.HTTP_401_UNAUTHORIZED:
+        headers.setdefault("www-authenticate", "Bearer")
+    return JSONResponse(status_code=exc.status_code, content={"error": exc.detail}, headers=headers)

--- a/infra/local-dev/services/cognito-mock/Dockerfile
+++ b/infra/local-dev/services/cognito-mock/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential libssl-dev libffi-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
+
+COPY cognito-mock/app ./app
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/infra/local-dev/services/cognito-mock/app/main.py
+++ b/infra/local-dev/services/cognito-mock/app/main.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import base64
+import os
+import time
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import List, Optional
+
+import jwt
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from fastapi import FastAPI, HTTPException, status
+from pydantic import BaseModel, Field
+
+app = FastAPI(title="Cognito Mock", version="0.1.0")
+
+COGNITO_ISSUER = os.getenv("COGNITO_ISSUER", "http://cognito-mock:8000")
+COGNITO_KEY_ID = os.getenv("COGNITO_KEY_ID", "local-dev-key")
+COGNITO_APP_CLIENT_ID = os.getenv("COGNITO_APP_CLIENT_ID", "local-dev-client")
+DEFAULT_AUDIENCES = [
+    audience.strip()
+    for audience in os.getenv("COGNITO_DEFAULT_AUDIENCES", "guidogerb-api,guidogerb-app").split(",")
+    if audience.strip()
+]
+TOKEN_TTL_SECONDS = int(os.getenv("COGNITO_TOKEN_TTL", "3600"))
+
+_private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+_public_key = _private_key.public_key()
+
+_private_pem = _private_key.private_bytes(
+    encoding=serialization.Encoding.PEM,
+    format=serialization.PrivateFormat.PKCS8,
+    encryption_algorithm=serialization.NoEncryption(),
+)
+_public_pem = _public_key.public_bytes(
+    encoding=serialization.Encoding.PEM,
+    format=serialization.PublicFormat.SubjectPublicKeyInfo,
+)
+
+
+def _b64(number: int) -> str:
+    return base64.urlsafe_b64encode(number.to_bytes((number.bit_length() + 7) // 8, "big")).rstrip(b"=").decode()
+
+
+def _jwks_document() -> dict:
+    numbers = _public_key.public_numbers()
+    return {
+        "keys": [
+            {
+                "kty": "RSA",
+                "kid": COGNITO_KEY_ID,
+                "use": "sig",
+                "alg": "RS256",
+                "e": _b64(numbers.e),
+                "n": _b64(numbers.n),
+            }
+        ]
+    }
+
+
+class TokenRequest(BaseModel):
+    username: str = Field(default="demo-user")
+    audience: Optional[str] = None
+    ttl_seconds: Optional[int] = Field(default=None, ge=60, le=86400)
+    client_id: Optional[str] = None
+    groups: Optional[List[str]] = Field(default_factory=list)
+
+
+@app.get("/healthz")
+async def health() -> dict:
+    return {"status": "ok", "issuer": COGNITO_ISSUER}
+
+
+@app.get("/.well-known/jwks.json")
+async def jwks() -> dict:
+    return _jwks_document()
+
+
+@app.get("/.well-known/openid-configuration")
+async def openid_configuration() -> dict:
+    return {
+        "issuer": COGNITO_ISSUER,
+        "jwks_uri": f"{COGNITO_ISSUER}/.well-known/jwks.json",
+        "token_endpoint": f"{COGNITO_ISSUER}/token",
+        "response_types_supported": ["code", "token"],
+        "subject_types_supported": ["public"],
+        "id_token_signing_alg_values_supported": ["RS256"],
+        "claims_supported": ["sub", "email", "username", "cognito:groups"],
+    }
+
+
+@app.post("/token")
+async def issue_token(request: TokenRequest) -> dict:
+    audience = request.audience or (DEFAULT_AUDIENCES[0] if DEFAULT_AUDIENCES else None)
+    if not audience:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Audience is required")
+
+    if DEFAULT_AUDIENCES and audience not in DEFAULT_AUDIENCES:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Audience '{audience}' is not registered for this mock pool",
+        )
+
+    ttl = request.ttl_seconds or TOKEN_TTL_SECONDS
+    now = datetime.now(tz=timezone.utc)
+    expires_at = now + timedelta(seconds=ttl)
+
+    payload = {
+        "sub": str(uuid.uuid4()),
+        "iss": COGNITO_ISSUER,
+        "token_use": "id",
+        "aud": audience,
+        "client_id": request.client_id or COGNITO_APP_CLIENT_ID,
+        "username": request.username,
+        "email": f"{request.username}@example.com",
+        "cognito:groups": request.groups or ["local-dev"],
+        "auth_time": int(time.mktime(now.timetuple())),
+        "iat": int(now.timestamp()),
+        "exp": int(expires_at.timestamp()),
+    }
+
+    token = jwt.encode(payload, _private_pem, algorithm="RS256", headers={"kid": COGNITO_KEY_ID})
+    return {
+        "access_token": token,
+        "token_type": "Bearer",
+        "expires_in": ttl,
+        "issued_token_type": "urn:ietf:params:oauth:token-type:access_token",
+    }
+
+
+@app.get("/public-key.pem")
+async def public_key() -> dict:
+    return {"public_key": _public_pem.decode()}

--- a/infra/local-dev/services/fargate/Dockerfile
+++ b/infra/local-dev/services/fargate/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential libssl-dev libffi-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
+
+COPY fargate/app ./app
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "9001"]

--- a/infra/local-dev/services/fargate/app/main.py
+++ b/infra/local-dev/services/fargate/app/main.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict, List
+
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+
+app = FastAPI(title="Fargate Service", version="0.1.0")
+
+_SAMPLE_ORDERS: List[Dict[str, Any]] = [
+    {
+        "id": "ord_1001",
+        "status": "processing",
+        "total": 48.95,
+        "currency": "USD",
+        "updated_at": datetime(2024, 7, 21, 10, 15, tzinfo=timezone.utc).isoformat(),
+    },
+    {
+        "id": "ord_1002",
+        "status": "fulfilled",
+        "total": 12.0,
+        "currency": "USD",
+        "updated_at": datetime(2024, 8, 2, 8, 45, tzinfo=timezone.utc).isoformat(),
+    },
+]
+
+
+def _context(request: Request) -> Dict[str, Any]:
+    return {
+        "tenant": request.headers.get("x-guidogerb-tenant", "unknown"),
+        "username": request.headers.get("x-guidogerb-username", "anonymous"),
+        "target": request.headers.get("x-guidogerb-target", "fargate"),
+    }
+
+
+@app.get("/healthz")
+async def health() -> dict:
+    return {"status": "ok", "service": "fargate"}
+
+
+@app.get("/orders")
+async def list_orders(request: Request) -> dict:
+    context = _context(request)
+    return {
+        "orders": _SAMPLE_ORDERS,
+        **context,
+        "count": len(_SAMPLE_ORDERS),
+    }
+
+
+@app.post("/orders")
+async def create_order(request: Request) -> JSONResponse:
+    context = _context(request)
+    payload = await request.json()
+    payload.setdefault("id", "ord-dev-" + datetime.now(tz=timezone.utc).strftime("%H%M%S"))
+    payload.setdefault("status", "created")
+    payload.setdefault("currency", "USD")
+    payload.setdefault("created_at", datetime.now(tz=timezone.utc).isoformat())
+    return JSONResponse({"result": "accepted", **context, "order": payload})
+
+
+@app.api_route("/{path:path}", methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"])
+async def fallback(path: str, request: Request) -> JSONResponse:
+    context = _context(request)
+    try:
+        payload = await request.json()
+    except Exception:  # noqa: BLE001 - propagate non JSON bodies as-is
+        payload = (await request.body()).decode() or None
+    return JSONResponse(
+        {
+            "source": "fargate",
+            **context,
+            "path": path,
+            "method": request.method,
+            "payload": payload,
+            "query": dict(request.query_params),
+        }
+    )

--- a/infra/local-dev/services/lambda/Dockerfile
+++ b/infra/local-dev/services/lambda/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential libssl-dev libffi-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
+
+COPY lambda/app ./app
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "9000"]

--- a/infra/local-dev/services/lambda/app/main.py
+++ b/infra/local-dev/services/lambda/app/main.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+
+app = FastAPI(title="Lambda Simulation", version="0.1.0")
+
+
+def _base_context(request: Request) -> Dict[str, Any]:
+    return {
+        "tenant": request.headers.get("x-guidogerb-tenant", "unknown"),
+        "username": request.headers.get("x-guidogerb-username", "anonymous"),
+        "target": request.headers.get("x-guidogerb-target", "lambda"),
+    }
+
+
+@app.get("/healthz")
+async def health() -> dict:
+    return {"status": "ok", "service": "lambda"}
+
+
+@app.get("/hello")
+async def hello(request: Request) -> dict:
+    context = _base_context(request)
+    return {
+        "message": "Hello from the lambda function",
+        **context,
+        "path": str(request.url.path),
+    }
+
+
+@app.post("/echo")
+async def echo(request: Request) -> JSONResponse:
+    context = _base_context(request)
+    try:
+        payload = await request.json()
+    except Exception:  # noqa: BLE001 - fallback to bytes when body is not JSON
+        payload = await request.body()
+    return JSONResponse({"source": "lambda", **context, "payload": payload})
+
+
+@app.api_route("/{path:path}", methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"])
+async def catch_all(path: str, request: Request) -> JSONResponse:
+    context = _base_context(request)
+    body: Any
+    try:
+        body = await request.json()
+    except Exception:  # noqa: BLE001 - non JSON bodies bubble through
+        body = (await request.body()).decode() or None
+    return JSONResponse(
+        {
+            "source": "lambda",
+            **context,
+            "path": path,
+            "method": request.method,
+            "query": dict(request.query_params),
+            "body": body,
+        }
+    )

--- a/infra/local-dev/services/requirements.txt
+++ b/infra/local-dev/services/requirements.txt
@@ -1,0 +1,5 @@
+fastapi==0.110.0
+uvicorn[standard]==0.29.0
+httpx==0.27.2
+PyJWT[crypto]==2.8.0
+cryptography==42.0.5


### PR DESCRIPTION
## Summary
- add an `infra/local-dev` docker-compose stack that emulates CloudFront + S3 and API Gateway routing to Lambda and Fargate services
- implement mock Cognito, API gateway, Lambda, and Fargate FastAPI services with JWT validation and tenant-aware routing
- document usage instructions, placeholder S3 content, and a sync script for copying website builds into the simulated buckets

## Testing
- python -m compileall infra/local-dev/services

------
https://chatgpt.com/codex/tasks/task_e_68d18e97a3488324a50baf2e4d256d0a