### PR TITLE
feat: add theme editor and catalog story playground

### DIFF
--- a/@guidogerb/components/catalog/src/__tests__/Catalog.stories.test.jsx
+++ b/@guidogerb/components/catalog/src/__tests__/Catalog.stories.test.jsx
@@ -2,6 +2,7 @@ import { render, screen, waitFor } from '@testing-library/react'
 import { describe, it, expect } from 'vitest'
 
 import {
+  CustomRenderer as CatalogCustomRenderer,
   Default as CatalogDefault,
   ListView as CatalogListView,
   PhysicalFocus as CatalogPhysicalFocus,
@@ -13,7 +14,7 @@ const renderStory = (story) => {
   }
 
   if (story && typeof story.render === 'function') {
-    return render(story.render())
+    return render(story.render(story.args ?? {}))
   }
 
   throw new Error('Unsupported story shape')
@@ -41,6 +42,15 @@ describe('Catalog stories', () => {
 
     await waitFor(() => {
       expect(screen.getByRole('heading', { name: /physical shipment/i })).toBeInTheDocument()
+    })
+  })
+
+  it('renders the custom renderer story with bespoke markup', async () => {
+    renderStory(CatalogCustomRenderer)
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('custom-product').length).toBeGreaterThan(0)
+      expect(screen.getAllByText('Add to crate').length).toBeGreaterThan(0)
     })
   })
 })

--- a/@guidogerb/components/catalog/tasks.md
+++ b/@guidogerb/components/catalog/tasks.md
@@ -3,5 +3,5 @@
 | name                                        | createdDate | lastUpdatedDate | completedDate | status      | description                                                                                             |
 | ------------------------------------------- | ----------- | --------------- | ------------- | ----------- | ------------------------------------------------------------------------------------------------------- |
 | Document default GraphQL contract           | 2025-09-19  | 2025-09-19      | 2025-09-19    | complete    | Captured the baseline query, props, and normalization rules in the README for tenant integrators.       |
-| Build Storybook playground with mocked data | 2025-09-19  | 2025-09-19      | -             | in progress | Stand up interactive stories that let product owners explore filters, pagination, and custom renderers. |
+| Build Storybook playground with mocked data | 2025-09-19  | 2025-09-27      | 2025-09-27    | complete    | Stand up interactive stories that let product owners explore filters, pagination, and custom renderers. |
 | Implement tenant-scoped storage namespaces  | 2025-09-19  | 2025-09-22      | 2025-09-22    | complete    | Ensure persisted view preferences are isolated per tenant/environment to avoid leaking settings.        |

--- a/@guidogerb/css/README.md
+++ b/@guidogerb/css/README.md
@@ -10,6 +10,8 @@ web applications.
   notification for offline support)
 - `ThemeSelect` — ready-made selector that can be embedded in
   `@guidogerb/header` to switch between themes and create new ones
+- `ThemeEditor` — modal workflow for editing the active palette and saving it
+  as a reusable custom theme
 
 ## Usage
 
@@ -59,6 +61,30 @@ Custom themes inherit the rest of the design tokens from the currently active
 base theme and are stored alongside the active selection. Newly created themes
 become active immediately, making it easy to wire into the header via the
 `renderThemeToggle` slot.
+
+### ThemeEditor
+
+`ThemeEditor` surfaces the full color token set for the active theme inside a
+lightweight modal. It clones the current palette, lets the user tweak any of
+the core CSS variables, and persists the result via the shared storage helpers
+that `ThemeProvider` already monitors.
+
+```tsx
+import { ThemeProvider, ThemeEditor } from '@guidogerb/css'
+
+export function HeaderThemeControls() {
+  return (
+    <ThemeProvider>
+      <ThemeEditor triggerLabel="Customize" />
+    </ThemeProvider>
+  )
+}
+```
+
+When the editor form is submitted, a new custom theme is created (or the
+existing custom theme is updated) and automatically activated. Persisted
+payloads are broadcast to any subscribed service worker so offline caches can
+react immediately.
 
 Additional exports include:
 

--- a/@guidogerb/css/__tests__/ThemeEditor.test.jsx
+++ b/@guidogerb/css/__tests__/ThemeEditor.test.jsx
@@ -1,0 +1,108 @@
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  CUSTOM_THEMES_STORAGE_KEY,
+  SELECTED_THEME_STORAGE_KEY,
+  ThemeEditor,
+  ThemeProvider,
+} from '../index.js'
+
+describe('ThemeEditor', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    document.documentElement.removeAttribute('data-theme')
+    document.documentElement.style.cssText = ''
+  })
+
+  it('creates a custom theme and persists it via the provider', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <ThemeProvider>
+        <ThemeEditor triggerLabel="Customize" />
+      </ThemeProvider>,
+    )
+
+    await user.click(screen.getByRole('button', { name: /customize/i }))
+
+    const dialog = await screen.findByRole('dialog', { name: /theme editor/i })
+    const nameInput = within(dialog).getByLabelText('Theme name')
+    await user.clear(nameInput)
+    await user.type(nameInput, 'Ocean Surge')
+
+    const primaryColor = within(dialog).getByLabelText('Primary color')
+    fireEvent.input(primaryColor, { target: { value: '#0af0ff' } })
+    const bgColor = within(dialog).getByLabelText('Background color')
+    fireEvent.input(bgColor, { target: { value: '#020617' } })
+
+    await user.click(within(dialog).getByRole('button', { name: /save changes/i }))
+
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument())
+
+    await waitFor(() =>
+      expect(localStorage.getItem(SELECTED_THEME_STORAGE_KEY)).toMatch(/^ocean-surge/),
+    )
+
+    const storedThemes = JSON.parse(localStorage.getItem(CUSTOM_THEMES_STORAGE_KEY) ?? '[]')
+    expect(storedThemes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: 'Ocean Surge',
+          tokens: expect.objectContaining({
+            '--color-primary': '#0af0ff',
+            '--color-bg': '#020617',
+          }),
+        }),
+      ]),
+    )
+
+    await waitFor(() =>
+      expect(document.documentElement.style.getPropertyValue('--color-primary')).toBe('#0af0ff'),
+    )
+  })
+
+  it('prefills existing custom themes when reopened and updates them in place', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <ThemeProvider>
+        <ThemeEditor triggerLabel="Customize" />
+      </ThemeProvider>,
+    )
+
+    const openEditor = async () => {
+      await user.click(screen.getByRole('button', { name: /customize/i }))
+      return screen.findByRole('dialog', { name: /theme editor/i })
+    }
+
+    let dialog = await openEditor()
+    await user.clear(within(dialog).getByLabelText('Theme name'))
+    await user.type(within(dialog).getByLabelText('Theme name'), 'Ocean Base')
+    fireEvent.input(within(dialog).getByLabelText('Primary color'), {
+      target: { value: '#0ea5e9' },
+    })
+    await user.click(within(dialog).getByRole('button', { name: /save changes/i }))
+
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument())
+
+    dialog = await openEditor()
+    await waitFor(() =>
+      expect(within(dialog).getByLabelText('Theme name')).toHaveValue('Ocean Base'),
+    )
+
+    await user.clear(within(dialog).getByLabelText('Theme name'))
+    await user.type(within(dialog).getByLabelText('Theme name'), 'Ocean Deep')
+    fireEvent.input(within(dialog).getByLabelText('Primary color'), {
+      target: { value: '#0369a1' },
+    })
+    await user.click(within(dialog).getByRole('button', { name: /save changes/i }))
+
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument())
+
+    const storedThemes = JSON.parse(localStorage.getItem(CUSTOM_THEMES_STORAGE_KEY) ?? '[]')
+    expect(storedThemes).toHaveLength(1)
+    expect(storedThemes[0]).toMatchObject({ name: 'Ocean Deep' })
+  })
+})

--- a/@guidogerb/css/index.js
+++ b/@guidogerb/css/index.js
@@ -1,6 +1,7 @@
 export { ThemeProvider } from './src/ThemeProvider.jsx'
 export { ThemeContext } from './src/ThemeContext.js'
 export { ThemeSelect } from './src/ThemeSelect.jsx'
+export { ThemeEditor } from './src/ThemeEditor.jsx'
 export { useTheme } from './src/useTheme.js'
 export {
   DEFAULT_THEME_ID,

--- a/@guidogerb/css/src/ThemeEditor.jsx
+++ b/@guidogerb/css/src/ThemeEditor.jsx
@@ -1,0 +1,253 @@
+import { useEffect, useId, useMemo, useState } from 'react'
+import { DEFAULT_THEMES } from './themes.js'
+import { useTheme } from './useTheme.js'
+import {
+  THEME_COLOR_FIELDS,
+  buildColorFormState,
+  extractTokensFromState,
+  sanitizeColorValue,
+} from './themeForm.js'
+
+const BASE_CLASS = 'gg-theme-editor'
+
+const buildClassName = (...values) => values.filter(Boolean).join(' ')
+
+const sanitizeString = (value) => (typeof value === 'string' ? value.trim() : '')
+
+const getThemeTokens = (theme) =>
+  theme?.tokens && typeof theme.tokens === 'object' ? theme.tokens : {}
+
+const getDefaultThemeName = (theme) => {
+  const name = sanitizeString(theme?.name)
+  if (!name) return 'Custom theme'
+  if (theme?.isCustom) return name
+  return `${name} custom`
+}
+
+const buildPreviewTokens = (formState) => extractTokensFromState(formState)
+
+const buildPreviewStyles = (tokens) => ({
+  backgroundColor: tokens['--color-bg'] ?? '#0b0c0f',
+  color: tokens['--color-text'] ?? '#e6e8ec',
+})
+
+const buildSurfaceStyles = (tokens) => ({
+  backgroundColor: tokens['--color-surface'] ?? '#111318',
+  color: tokens['--color-text'] ?? '#e6e8ec',
+  border: `1px solid ${tokens['--color-muted'] ?? '#a1a7b3'}`,
+})
+
+const buildAccentStyles = (tokens) => ({
+  backgroundColor: tokens['--color-primary'] ?? '#3b82f6',
+  color: tokens['--color-bg'] ?? '#0b0c0f',
+})
+
+export function ThemeEditor({
+  className,
+  triggerLabel = 'Customize theme',
+  title = 'Theme editor',
+  description = 'Adjust brand colors and save them as a reusable theme.',
+  cancelLabel = 'Cancel',
+  closeLabel = 'Close',
+  saveLabel = 'Save changes',
+  themeId,
+  onOpen,
+  onClose,
+  onSave,
+} = {}) {
+  const themeContext = useTheme()
+  const availableThemes = themeContext?.themes ?? []
+  const activeThemeId = themeId ?? themeContext?.activeThemeId ?? availableThemes[0]?.id ?? null
+
+  const resolvedTheme = useMemo(() => {
+    if (!availableThemes.length) return null
+    const explicit = availableThemes.find((candidate) => candidate?.id === activeThemeId)
+    if (explicit) return explicit
+    if (themeContext?.activeTheme) return themeContext.activeTheme
+    return availableThemes[0]
+  }, [availableThemes, activeThemeId, themeContext])
+
+  const baseTokens = useMemo(() => {
+    if (resolvedTheme) return getThemeTokens(resolvedTheme)
+    return getThemeTokens(DEFAULT_THEMES[0])
+  }, [resolvedTheme])
+
+  const colorDefaults = useMemo(() => buildColorFormState(baseTokens), [baseTokens])
+
+  const [isOpen, setIsOpen] = useState(false)
+  const [formState, setFormState] = useState(() => ({
+    name: getDefaultThemeName(resolvedTheme),
+    ...colorDefaults,
+  }))
+  const [targetThemeId, setTargetThemeId] = useState(() =>
+    resolvedTheme?.isCustom ? resolvedTheme.id : null,
+  )
+
+  useEffect(() => {
+    if (!isOpen) return
+    setFormState({ name: getDefaultThemeName(resolvedTheme), ...colorDefaults })
+    setTargetThemeId(resolvedTheme?.isCustom ? resolvedTheme.id : null)
+  }, [colorDefaults, isOpen, resolvedTheme])
+
+  const tokens = useMemo(() => buildPreviewTokens(formState), [formState])
+  const previewStyles = useMemo(() => buildPreviewStyles(tokens), [tokens])
+  const surfaceStyles = useMemo(() => buildSurfaceStyles(tokens), [tokens])
+  const accentStyles = useMemo(() => buildAccentStyles(tokens), [tokens])
+
+  const titleId = useId()
+  const descriptionId = useId()
+
+  if (!themeContext || availableThemes.length === 0) {
+    return null
+  }
+
+  const handleOpen = () => {
+    setIsOpen(true)
+    if (typeof onOpen === 'function') {
+      onOpen()
+    }
+  }
+
+  const handleClose = () => {
+    setIsOpen(false)
+    if (typeof onClose === 'function') {
+      onClose()
+    }
+  }
+
+  const handleInputChange = (event) => {
+    const { name, value } = event.target
+    setFormState((prev) => ({ ...prev, [name]: value }))
+  }
+
+  const handleSubmit = (event) => {
+    event.preventDefault()
+    const trimmedName = sanitizeString(formState.name)
+    if (!trimmedName) return
+    if (typeof themeContext.createCustomTheme !== 'function') return
+
+    const tokensFromState = extractTokensFromState(formState)
+
+    const createdTheme = themeContext.createCustomTheme(
+      {
+        id: targetThemeId ?? undefined,
+        name: trimmedName,
+        tokens: tokensFromState,
+      },
+      { baseTokens },
+    )
+
+    if (createdTheme) {
+      if (typeof onSave === 'function') {
+        onSave(createdTheme)
+      }
+      handleClose()
+    }
+  }
+
+  return (
+    <div className={buildClassName(BASE_CLASS, className)}>
+      <button
+        type="button"
+        className={`${BASE_CLASS}__trigger`}
+        onClick={handleOpen}
+        disabled={!availableThemes.length}
+      >
+        {triggerLabel}
+      </button>
+
+      {isOpen ? (
+        <div className={`${BASE_CLASS}__overlay`}>
+          <div
+            className={`${BASE_CLASS}__dialog`}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby={titleId}
+            aria-describedby={description ? descriptionId : undefined}
+          >
+            <header className={`${BASE_CLASS}__header`}>
+              <h2 id={titleId} className={`${BASE_CLASS}__title`}>
+                {title}
+              </h2>
+              {description ? (
+                <p id={descriptionId} className={`${BASE_CLASS}__description`}>
+                  {description}
+                </p>
+              ) : null}
+              <button type="button" className={`${BASE_CLASS}__close`} onClick={handleClose}>
+                {closeLabel}
+              </button>
+            </header>
+
+            <div className={`${BASE_CLASS}__content`}>
+              <form className={`${BASE_CLASS}__form`} onSubmit={handleSubmit}>
+                <div className={`${BASE_CLASS}__field`}>
+                  <label className={`${BASE_CLASS}__label`} htmlFor={`${titleId}-name`}>
+                    Theme name
+                  </label>
+                  <input
+                    id={`${titleId}-name`}
+                    className={`${BASE_CLASS}__input`}
+                    name="name"
+                    type="text"
+                    value={formState.name}
+                    onChange={handleInputChange}
+                    required
+                  />
+                </div>
+
+                <fieldset className={`${BASE_CLASS}__fieldset`}>
+                  <legend className={`${BASE_CLASS}__legend`}>Colors</legend>
+                  <div className={`${BASE_CLASS}__grid`}>
+                    {THEME_COLOR_FIELDS.map((field) => (
+                      <label
+                        key={field.key}
+                        className={`${BASE_CLASS}__field`}
+                        htmlFor={`${titleId}-${field.name}`}
+                      >
+                        <span className={`${BASE_CLASS}__label`}>{field.label}</span>
+                        <input
+                          id={`${titleId}-${field.name}`}
+                          className={`${BASE_CLASS}__input ${BASE_CLASS}__input--color`}
+                          type="color"
+                          name={field.name}
+                          value={sanitizeColorValue(formState[field.name]) ?? field.default}
+                          onChange={handleInputChange}
+                        />
+                      </label>
+                    ))}
+                  </div>
+                </fieldset>
+
+                <section className={`${BASE_CLASS}__preview`} aria-label="Theme preview">
+                  <div className={`${BASE_CLASS}__preview-wrapper`} style={previewStyles}>
+                    <div className={`${BASE_CLASS}__preview-card`} style={surfaceStyles}>
+                      <h3 className={`${BASE_CLASS}__preview-heading`}>Preview headline</h3>
+                      <p className={`${BASE_CLASS}__preview-copy`}>
+                        Adjust the palette to see real-time changes reflected in this preview card.
+                      </p>
+                      <button type="button" className={`${BASE_CLASS}__preview-action`} style={accentStyles}>
+                        Primary action
+                      </button>
+                    </div>
+                  </div>
+                </section>
+
+                <footer className={`${BASE_CLASS}__actions`}>
+                  <button type="button" className={`${BASE_CLASS}__button`} onClick={handleClose}>
+                    {cancelLabel}
+                  </button>
+                  <button type="submit" className={`${BASE_CLASS}__button ${BASE_CLASS}__button--primary`}>
+                    {saveLabel}
+                  </button>
+                </footer>
+              </form>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+export default ThemeEditor

--- a/@guidogerb/css/src/themeForm.js
+++ b/@guidogerb/css/src/themeForm.js
@@ -1,0 +1,44 @@
+const sanitizeColorValue = (value) => {
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+export const THEME_COLOR_FIELDS = [
+  { key: '--color-bg', name: 'colorBg', label: 'Background color', default: '#0b0c0f' },
+  { key: '--color-surface', name: 'colorSurface', label: 'Surface color', default: '#111318' },
+  { key: '--color-text', name: 'colorText', label: 'Text color', default: '#e6e8ec' },
+  { key: '--color-muted', name: 'colorMuted', label: 'Muted text color', default: '#a1a7b3' },
+  { key: '--color-primary', name: 'colorPrimary', label: 'Primary color', default: '#3b82f6' },
+  {
+    key: '--color-primary-600',
+    name: 'colorPrimaryStrong',
+    label: 'Primary (emphasis) color',
+    default: '#2563eb',
+  },
+  { key: '--color-success', name: 'colorSuccess', label: 'Success color', default: '#22c55e' },
+  { key: '--color-warning', name: 'colorWarning', label: 'Warning color', default: '#f59e0b' },
+  { key: '--color-danger', name: 'colorDanger', label: 'Danger color', default: '#ef4444' },
+]
+
+export const buildColorFormState = (tokens = {}) => {
+  const state = {}
+  THEME_COLOR_FIELDS.forEach((field) => {
+    const tokenValue = sanitizeColorValue(tokens[field.key])
+    state[field.name] = tokenValue ?? field.default
+  })
+  return state
+}
+
+export const extractTokensFromState = (state = {}) => {
+  const tokens = {}
+  THEME_COLOR_FIELDS.forEach((field) => {
+    const value = sanitizeColorValue(state[field.name])
+    if (value) {
+      tokens[field.key] = value
+    }
+  })
+  return tokens
+}
+
+export { sanitizeColorValue }

--- a/@guidogerb/css/tasks.md
+++ b/@guidogerb/css/tasks.md
@@ -3,5 +3,5 @@
 | name                               | createdDate | lastUpdatedDate | completedDate | status      | description                                                                                                       |
 | ---------------------------------- | ----------- | --------------- | ------------- | ----------- | ----------------------------------------------------------------------------------------------------------------- |
 | Refresh theming documentation      | 2025-09-19  | 2025-09-19      | 2025-09-19    | complete    | Ensured the README walks through reset imports, provider setup, and ThemeSelect embedding for tenant apps.        |
-| Build custom theme editor workflow | 2025-09-19  | 2025-09-19      | -             | in progress | Prototype a modal-driven editor that saves bespoke token sets through the storage helpers and broadcasts updates. |
+| Build custom theme editor workflow | 2025-09-19  | 2025-09-27      | 2025-09-27    | complete    | Prototype a modal-driven editor that saves bespoke token sets through the storage helpers and broadcasts updates. |
 | Add design-token regression checks | 2025-09-19  | 2025-09-21      | 2025-09-21    | complete    | Capture screenshot/DOM snapshots so token regressions are caught before publishing shared CSS.                    |


### PR DESCRIPTION
## Summary
- add a modal-driven ThemeEditor component with shared color form utilities, documentation, and tests
- update ThemeSelect to reuse the new helpers and export the editor
- expand the catalog Storybook playground with richer mocked data options and add a custom renderer story

## Testing
- pnpm --filter @guidogerb/css test
- pnpm --filter @guidogerb/components-catalog test

------
https://chatgpt.com/codex/tasks/task_e_68d335662f7c8324b7970100b1664b81