### PR TITLE
feat: add responsive-slot module exports and typings

### DIFF
--- a/@guidogerb/components/ui/GuidoGerbUI_Container.spec.md
+++ b/@guidogerb/components/ui/GuidoGerbUI_Container.spec.md
@@ -452,8 +452,8 @@ src/
 
 #### 1) Foundations
 
-- [ ] Create `responsive-slot` module and exports from `@guidogerb/components/ui`.
-- [ ] Implement `SlotSizeMap`, `BreakpointKey`, `Registry` types with strict TS.
+- [x] Create `responsive-slot` module and exports from `@guidogerb/components/ui`.
+- [x] Implement `SlotSizeMap`, `BreakpointKey`, `Registry` types with strict TS.
 - [ ] Implement base presets (`catalog.card`, `dashboard.panel`, `hero.banner`, `list.row`).
 
 #### 2) Breakpoints & Sizing

--- a/@guidogerb/components/ui/__tests__/responsive-slot.module.test.jsx
+++ b/@guidogerb/components/ui/__tests__/responsive-slot.module.test.jsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react'
+
+import {
+  GuidoGerbUI_Container,
+  ResponsiveSlot,
+  ResponsiveSlotProvider,
+  responsiveSlotBreakpoints,
+  baseResponsiveSlots,
+} from '../src/responsive-slot/index.js'
+
+describe('responsive-slot module exports', () => {
+  it('aliases GuidoGerbUI_Container to the existing ResponsiveSlot component', () => {
+    expect(ResponsiveSlot).toBe(GuidoGerbUI_Container)
+
+    render(
+      <ResponsiveSlotProvider defaultBreakpoint="lg">
+        <GuidoGerbUI_Container slot="catalog.card" data-testid="slot">
+          <div>Content</div>
+        </GuidoGerbUI_Container>
+      </ResponsiveSlotProvider>,
+    )
+
+    const slot = screen.getByTestId('slot')
+    expect(slot.dataset.slotKey).toBe('catalog.card')
+    expect(slot.dataset.slotLabel).toBe('Catalog Card')
+  })
+
+  it('exposes breakpoint descriptors and base presets', () => {
+    const keys = responsiveSlotBreakpoints.map((entry) => entry.key)
+    expect(keys).toContain('xs')
+    expect(keys).toContain('xl')
+
+    expect(baseResponsiveSlots['hero.banner']).toBeDefined()
+    expect(baseResponsiveSlots['dashboard.panel']).toBeDefined()
+  })
+})

--- a/@guidogerb/components/ui/__tests__/responsive-slot.types.test.ts
+++ b/@guidogerb/components/ui/__tests__/responsive-slot.types.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expectTypeOf, expect } from 'vitest'
+
+import { responsiveSlotBreakpoints, baseResponsiveSlots } from '../src/responsive-slot/index.js'
+import type {
+  BreakpointKey,
+  SlotSizeMap,
+  SlotSizeOverrides,
+  Registry,
+  GuidoGerbUI_ContainerProps,
+  ResponsiveSlotSize,
+} from '../src/responsive-slot'
+
+describe('responsive-slot type definitions', () => {
+  it('exposes the expected breakpoint union and responsive size type', () => {
+    const keys = responsiveSlotBreakpoints.map((entry) => entry.key)
+    expectTypeOf(keys[0]).toMatchTypeOf<BreakpointKey>()
+
+    expectTypeOf<ResponsiveSlotSize>().toMatchTypeOf<{
+      inline: string
+      block: string
+      breakpoint: BreakpointKey
+    }>()
+  })
+
+  it('allows authoring registries with typed slot size maps', () => {
+    const overrides: SlotSizeOverrides = {
+      md: { inline: '20rem', block: 320 },
+      xl: { maxInline: 'token:space-4' },
+    }
+
+    const registry: Registry = {
+      'custom.slot': {
+        sizes: overrides,
+        meta: { label: 'Custom Slot' },
+      },
+    }
+
+    expect(baseResponsiveSlots['catalog.card']).toBeDefined()
+    expect(registry['custom.slot']).toBeDefined()
+  })
+
+  it('supports polymorphic container props with required slot key', () => {
+    const props: GuidoGerbUI_ContainerProps<'section'> = {
+      as: 'section',
+      slot: 'catalog.card',
+      sizes: {
+        md: { inline: '30rem', block: '28rem' } satisfies SlotSizeMap,
+      },
+    }
+
+    expect(props.slot).toBe('catalog.card')
+  })
+})

--- a/@guidogerb/components/ui/index.js
+++ b/@guidogerb/components/ui/index.js
@@ -1,8 +1,8 @@
+// Public responsive slot exports
+export * from './src/responsive-slot/index.js'
+
 // Re-export library entry for consumers that import from the package root
 export * from './src/JsonViewer/JsonViewer.jsx'
-export * from './src/ResponsiveSlot/ResponsiveSlot.jsx'
-export { EditModeProvider, useEditMode } from './src/ResponsiveSlot/editing/EditModeContext.jsx'
-export { JsonEditor } from './src/ResponsiveSlot/editing/JsonEditor.jsx'
 
 // Marketing site sections
 export { HeroSection } from './src/sections/HeroSection.jsx'

--- a/@guidogerb/components/ui/package.json
+++ b/@guidogerb/components/ui/package.json
@@ -13,6 +13,11 @@
     ".": {
       "import": "./index.js",
       "require": "./index.js"
+    },
+    "./responsive-slot": {
+      "types": "./src/responsive-slot/index.d.ts",
+      "import": "./src/responsive-slot/index.js",
+      "require": "./src/responsive-slot/index.js"
     }
   },
   "files": [
@@ -23,7 +28,9 @@
     "src/ResponsiveSlot/editing/JsonEditor.jsx",
     "src/ResponsiveSlot/editing/SlotEditorOverlay.jsx",
     "src/ResponsiveSlot/editing/useSlotEditing.js",
-    "src/ResponsiveSlot/editing/localDraftStorage.js"
+    "src/ResponsiveSlot/editing/localDraftStorage.js",
+    "src/responsive-slot/index.js",
+    "src/responsive-slot/index.d.ts"
   ],
   "peerDependencies": {
     "react": "^18.2.0 || ^19.0.0",

--- a/@guidogerb/components/ui/src/responsive-slot/index.d.ts
+++ b/@guidogerb/components/ui/src/responsive-slot/index.d.ts
@@ -1,0 +1,225 @@
+import * as React from 'react'
+
+export type BreakpointKey = 'xs' | 'sm' | 'md' | 'lg' | 'xl'
+
+export interface SlotSizeMap {
+  inline: number | string
+  block: number | string
+  maxInline?: number | string
+  maxBlock?: number | string
+  minInline?: number | string
+  minBlock?: number | string
+}
+
+export type SlotSizeOverrides = Partial<Record<BreakpointKey, Partial<SlotSizeMap> | SlotSizeMap>>
+
+export interface SlotVariantMeta {
+  label?: string
+  description?: string
+}
+
+export interface SlotDesignMeta {
+  figmaComponent?: string
+  figmaNodeId?: string
+  figmaUrl?: string
+}
+
+export interface SlotMeta {
+  label?: string
+  description?: string
+  design?: SlotDesignMeta
+  variants?: Record<string, SlotVariantMeta>
+  defaultVariant?: string
+  tags?: string | string[]
+}
+
+export interface SlotDefinition {
+  sizes?: SlotSizeOverrides
+  meta?: SlotMeta
+  extends?: string
+}
+
+export type RegistryEntry = SlotDefinition | SlotSizeOverrides
+export type Registry = Record<string, RegistryEntry>
+
+export interface ResponsiveSlotProviderProps {
+  registry?: Registry
+  defaultBreakpoint?: BreakpointKey
+  tokens?: Record<string, string | number>
+  resolveToken?: (tokenName: string) => string | number | undefined | null
+  children?: React.ReactNode
+}
+
+export interface ResponsiveSlotSize {
+  inline: string
+  block: string
+  maxInline: string
+  maxBlock: string
+  minInline: string
+  minBlock: string
+  breakpoint: BreakpointKey
+}
+
+export type ResponsiveSlotStatus = 'idle' | 'saving' | 'error'
+
+export interface SlotDraft {
+  version: 1
+  editableId?: string
+  slotKey?: string
+  variant?: string | null
+  sizes?: SlotSizeOverrides
+  propsJSON?: Record<string, unknown>
+  updatedAt?: string
+}
+
+export interface OverflowEvent {
+  id: string
+  inlineBudget: string
+  blockBudget: string
+  breakpoint: BreakpointKey
+  timestamp: number
+}
+
+export interface ResponsiveSlotEditingState {
+  isEditable: boolean
+  isEditingEnabled: boolean
+  isActive: boolean
+  shouldShowOverlay: boolean
+  setActive: () => void
+  recordOverflow: (event: { inlineBudget: string; blockBudget: string; breakpoint: BreakpointKey }) => void
+  publishDraft: () => Promise<SlotDraft | null>
+  discardDraft: () => void
+  updateSize: (breakpoint: BreakpointKey, dimension: keyof SlotSizeMap, value: string | number | null | undefined) => void
+  updateVariant: (variant?: string | null) => void
+  updateProps: (props: Record<string, unknown> | undefined) => void
+  clearBreakpoint: (breakpoint: BreakpointKey) => void
+  overrides?: SlotSizeOverrides
+  variant?: string | null
+  props?: Record<string, unknown> | null
+  draft: SlotDraft | null
+  status: ResponsiveSlotStatus
+  error: Error | null
+  isDirty: boolean
+  overflowEvents: OverflowEvent[]
+  lastUpdatedAt: string | null
+}
+
+export interface ResponsiveSlotInstance {
+  slot: string
+  variant: string
+  props?: Record<string, unknown> | null
+  meta?: SlotMeta
+  byBreakpoint: SlotSizeOverrides
+  editing?: ResponsiveSlotEditingState
+}
+
+type ElementProps<E extends React.ElementType> = Omit<React.ComponentPropsWithRef<E>, keyof GuidoGerbUI_ContainerBaseProps>
+
+export interface GuidoGerbUI_ContainerBaseProps {
+  slot: string
+  sizes?: SlotSizeOverrides | 'content'
+  inherit?: boolean
+  overflow?: React.CSSProperties['overflow']
+  editableId?: string
+  variant?: string
+  propsJSON?: Record<string, unknown> | null
+  children?: React.ReactNode
+}
+
+export type GuidoGerbUI_ContainerProps<E extends React.ElementType = 'div'> = GuidoGerbUI_ContainerBaseProps & {
+  as?: E
+} & ElementProps<E>
+
+export function ResponsiveSlotProvider(props: ResponsiveSlotProviderProps): JSX.Element
+
+export function useResponsiveSlotSize(
+  slot: string,
+  overrides?: SlotSizeOverrides | 'content',
+): ResponsiveSlotSize
+
+export function useResponsiveSlotMeta(slot: string): SlotMeta
+
+export function useResponsiveSlotInstance(): ResponsiveSlotInstance | null
+
+export function GuidoGerbUI_Container<E extends React.ElementType = 'div'>(
+  props: GuidoGerbUI_ContainerProps<E>,
+): JSX.Element
+
+export { GuidoGerbUI_Container as ResponsiveSlot }
+
+export const responsiveSlotBreakpoints: ReadonlyArray<{ key: BreakpointKey; query: string }>
+
+export const baseResponsiveSlots: Registry
+
+export interface EditModeProviderProps {
+  children?: React.ReactNode
+  initialMode?: boolean
+  graphqlEndpoint?: string | null
+  graphqlHeaders?:
+    | Record<string, string>
+    | null
+    | (() => Record<string, string> | undefined)
+  fetcher?: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
+}
+
+export interface EditModeContextValue {
+  isEditing: boolean
+  activeEditableId: string | null
+  setActiveEditableId: (editableId: string | null) => void
+  toggleEditMode: () => void
+  enterEditMode: () => void
+  exitEditMode: () => void
+  graphqlEndpoint: string | null
+  graphqlHeaders:
+    | Record<string, string>
+    | null
+    | (() => Record<string, string> | undefined)
+  fetcher: ((input: RequestInfo | URL, init?: RequestInit) => Promise<Response>) | null
+}
+
+export function EditModeProvider(props: EditModeProviderProps): JSX.Element
+export function useEditMode(): EditModeContextValue
+
+export interface JsonEditorProps {
+  label?: string
+  value?: unknown
+  onChange?: (value: unknown) => void
+  onErrorChange?: (error: string | null) => void
+  rows?: number
+  id?: string
+  description?: React.ReactNode
+  containerStyle?: React.CSSProperties
+  labelProps?: React.LabelHTMLAttributes<HTMLLabelElement>
+  textareaProps?: React.TextareaHTMLAttributes<HTMLTextAreaElement>
+  errorMessagePrefix?: string
+}
+
+export function JsonEditor(props: JsonEditorProps): JSX.Element
+
+export interface SlotEditorOverlayProps {
+  slotKey: string
+  slotLabel: string
+  editableId?: string
+  variant: string
+  variantOptions: Record<string, SlotVariantMeta>
+  onVariantChange: (variant: string) => void
+  breakpoints: ReadonlyArray<{ key: BreakpointKey; query: string }>
+  activeBreakpoint: BreakpointKey
+  sizes: SlotSizeOverrides
+  draftSizes: SlotSizeOverrides
+  onSizeChange: (breakpoint: BreakpointKey, dimension: keyof SlotSizeMap, value: string | number | null | undefined) => void
+  onClearBreakpoint: (breakpoint: BreakpointKey) => void
+  propsJSON?: Record<string, unknown> | null
+  onPropsChange: (props: Record<string, unknown> | undefined) => void
+  publishDraft: () => Promise<SlotDraft | null>
+  discardDraft: () => void
+  isDirty: boolean
+  status: ResponsiveSlotStatus
+  error: Error | null
+  lastUpdatedAt: string | null
+  overflowEvents: OverflowEvent[]
+  isActive: boolean
+  onActivate: () => void
+}
+
+export function SlotEditorOverlay(props: SlotEditorOverlayProps): JSX.Element

--- a/@guidogerb/components/ui/src/responsive-slot/index.js
+++ b/@guidogerb/components/ui/src/responsive-slot/index.js
@@ -1,0 +1,14 @@
+export {
+  ResponsiveSlotProvider,
+  useResponsiveSlotSize,
+  useResponsiveSlotMeta,
+  useResponsiveSlotInstance,
+  responsiveSlotBreakpoints,
+  baseResponsiveSlots,
+  ResponsiveSlot as GuidoGerbUI_Container,
+  ResponsiveSlot,
+} from '../ResponsiveSlot/ResponsiveSlot.jsx'
+
+export { EditModeProvider, useEditMode } from '../ResponsiveSlot/editing/EditModeContext.jsx'
+export { JsonEditor } from '../ResponsiveSlot/editing/JsonEditor.jsx'
+export { SlotEditorOverlay } from '../ResponsiveSlot/editing/SlotEditorOverlay.jsx'


### PR DESCRIPTION
## Summary
- add a dedicated responsive-slot entry point that aliases GuidoGerbUI_Container and related hooks
- provide strict TypeScript definitions for responsive slot breakpoints, registries, and editing helpers
- cover the new module with runtime and type-focused tests and mark spec tasks complete

## Testing
- pnpm --filter @guidogerb/components-ui test

------
https://chatgpt.com/codex/tasks/task_e_68d339038804832485e2788a1006ba0c