### PR TITLE
Implement responsive slot double buffering and metrics

### DIFF
--- a/@guidogerb/components/ui/GuidoGerbUI_Container.spec.md
+++ b/@guidogerb/components/ui/GuidoGerbUI_Container.spec.md
@@ -461,7 +461,7 @@ src/
 - [ ] Build `useBreakpointKey()` with `matchMedia` subscriptions and cleanup.
 - [ ] Add SSR/SSG default fallback support via provider prop.
 - [ ] Build `resolveSizes(slotKey, bp, overrides)` with deep merge + fallbacks.
-- [ ] Implement double‑buffered CSS variable algorithm and atomic flip.
+- [x] Implement double‑buffered CSS variable algorithm and atomic flip.
 - [ ] Expose `useResponsiveSlotSize()` hook returning resolved sizes + active breakpoint.
 
 #### 3) Wrapper Component
@@ -506,7 +506,7 @@ src/
 ### 8) Diagnostics & Perf
 
 - [ ] Implement shared `ResizeObserver` hook; log overflows (dev only).
-- [ ] Add perf marks around hydrate flip; expose counters in `window.__GG__` (dev only).
+- [x] Add perf marks around hydrate flip; expose counters in `window.__GG__` (dev only).
 
 #### 9) Testing
 

--- a/@guidogerb/components/ui/__tests__/ResponsiveSlot.visual.test.jsx
+++ b/@guidogerb/components/ui/__tests__/ResponsiveSlot.visual.test.jsx
@@ -47,6 +47,7 @@ describe('ResponsiveSlot visual baselines', () => {
       <div
         data-design-component="Catalog / Card"
         data-design-node="0:1"
+        data-slot-buffer="B"
         data-slot-default-variant="default"
         data-slot-description="Product tile used in merchandising grids and featured carousels."
         data-slot-key="catalog.card"
@@ -55,7 +56,7 @@ describe('ResponsiveSlot visual baselines', () => {
         data-slot-variant="default"
         data-slot-variant-label="Default"
         role="presentation"
-        style="--slot-inline-size: 24rem; --slot-block-size: 26rem; --slot-max-inline-size: none; --slot-max-block-size: none; --slot-min-inline-size: auto; --slot-min-block-size: auto; inline-size: var(--slot-inline-size); block-size: var(--slot-block-size); max-inline-size: var(--slot-max-inline-size); max-block-size: var(--slot-max-block-size); min-inline-size: var(--slot-min-inline-size); min-block-size: var(--slot-min-block-size); contain: layout paint style; display: grid; place-items: stretch; overflow: hidden auto; position: relative;"
+        style="--slot-inline-size-A: 22rem; --slot-block-size-A: 26rem; --slot-max-inline-size-A: none; --slot-max-block-size-A: none; --slot-min-inline-size-A: auto; --slot-min-block-size-A: auto; --slot-inline-A: 22rem; --slot-block-A: 26rem; --slot-max-inline-A: none; --slot-max-block-A: none; --slot-min-inline-A: auto; --slot-min-block-A: auto; --slot-inline-size-B: 24rem; --slot-block-size-B: 26rem; --slot-max-inline-size-B: none; --slot-max-block-size-B: none; --slot-min-inline-size-B: auto; --slot-min-block-size-B: auto; --slot-inline-B: 24rem; --slot-block-B: 26rem; --slot-max-inline-B: none; --slot-max-block-B: none; --slot-min-inline-B: auto; --slot-min-block-B: auto; --slot-inline-size: 24rem; --slot-block-size: 26rem; --slot-max-inline-size: none; --slot-max-block-size: none; --slot-min-inline-size: auto; --slot-min-block-size: auto; --slot-inline: 24rem; --slot-block: 26rem; --slot-max-inline: none; --slot-max-block: none; --slot-min-inline: auto; --slot-min-block: auto; inline-size: var(--slot-inline); block-size: var(--slot-block); max-inline-size: var(--slot-max-inline); max-block-size: var(--slot-max-block); min-inline-size: var(--slot-min-inline); min-block-size: var(--slot-min-block); contain: layout paint style; display: grid; place-items: stretch; overflow: hidden auto; position: relative;"
       >
         <div>
           Baseline
@@ -79,6 +80,7 @@ describe('ResponsiveSlot visual baselines', () => {
       <div
         data-design-component="Catalog / Card"
         data-design-node="0:1"
+        data-slot-buffer="B"
         data-slot-default-variant="default"
         data-slot-description="Product tile used in merchandising grids and featured carousels."
         data-slot-key="catalog.card"
@@ -87,7 +89,7 @@ describe('ResponsiveSlot visual baselines', () => {
         data-slot-variant="default"
         data-slot-variant-label="Default"
         role="presentation"
-        style="--slot-inline-size: min(100%, 20rem); --slot-block-size: 24rem; --slot-max-inline-size: none; --slot-max-block-size: none; --slot-min-inline-size: auto; --slot-min-block-size: auto; inline-size: var(--slot-inline-size); block-size: var(--slot-block-size); max-inline-size: var(--slot-max-inline-size); max-block-size: var(--slot-max-block-size); min-inline-size: var(--slot-min-inline-size); min-block-size: var(--slot-min-block-size); contain: layout paint style; display: grid; place-items: stretch; overflow: hidden auto; position: relative;"
+        style="--slot-inline-size-A: 22rem; --slot-block-size-A: 26rem; --slot-max-inline-size-A: none; --slot-max-block-size-A: none; --slot-min-inline-size-A: auto; --slot-min-block-size-A: auto; --slot-inline-A: 22rem; --slot-block-A: 26rem; --slot-max-inline-A: none; --slot-max-block-A: none; --slot-min-inline-A: auto; --slot-min-block-A: auto; --slot-inline-size-B: min(100%, 20rem); --slot-block-size-B: 24rem; --slot-max-inline-size-B: none; --slot-max-block-size-B: none; --slot-min-inline-size-B: auto; --slot-min-block-size-B: auto; --slot-inline-B: min(100%, 20rem); --slot-block-B: 24rem; --slot-max-inline-B: none; --slot-max-block-B: none; --slot-min-inline-B: auto; --slot-min-block-B: auto; --slot-inline-size: min(100%, 20rem); --slot-block-size: 24rem; --slot-max-inline-size: none; --slot-max-block-size: none; --slot-min-inline-size: auto; --slot-min-block-size: auto; --slot-inline: min(100%, 20rem); --slot-block: 24rem; --slot-max-inline: none; --slot-max-block: none; --slot-min-inline: auto; --slot-min-block: auto; inline-size: var(--slot-inline); block-size: var(--slot-block); max-inline-size: var(--slot-max-inline); max-block-size: var(--slot-max-block); min-inline-size: var(--slot-min-inline); min-block-size: var(--slot-min-block); contain: layout paint style; display: grid; place-items: stretch; overflow: hidden auto; position: relative;"
       >
         <div>
           Baseline


### PR DESCRIPTION
## Summary
- add a double-buffered CSS variable system for ResponsiveSlot so hydration flips are atomic and expose the active phase
- record buffer flip metrics in development by incrementing window.__GG__ counters and emitting performance marks
- extend the test suite and visual snapshots to cover the new buffering behaviour and mark the spec tasks as complete

## Testing
- pnpm --filter @guidogerb/components-ui test

------
https://chatgpt.com/codex/tasks/task_e_68d33f2abc8c83248653a4e1a808a836