### PR TITLE
Add responsive slot size resolver and token warnings

### DIFF
--- a/@guidogerb/components/ui/GuidoGerbUI_Container.spec.md
+++ b/@guidogerb/components/ui/GuidoGerbUI_Container.spec.md
@@ -460,7 +460,7 @@ src/
 
 - [x] Build `useBreakpointKey()` with `matchMedia` subscriptions and cleanup.
 - [ ] Add SSR/SSG default fallback support via provider prop.
-- [ ] Build `resolveSizes(slotKey, bp, overrides)` with deep merge + fallbacks.
+- [x] Build `resolveSizes(slotKey, bp, overrides)` with deep merge + fallbacks.
 - [x] Implement double‑buffered CSS variable algorithm and atomic flip.
 - [ ] Expose `useResponsiveSlotSize()` hook returning resolved sizes + active breakpoint.
 
@@ -469,7 +469,7 @@ src/
 - [ ] Implement `GuidoGerbUI_Container` with `as`, `inherit`, `overflow`, `min*`/`max*` handling.
 - [ ] Apply logical sizing (`inline-size`, `block-size`, etc.) and `contain: layout paint style`.
 - [ ] Accessibility: default `role="presentation"`, passthrough ARIA props.
-- [ ] Dev only: warn on unknown `slot` keys or invalid size tokens.
+- [x] Dev only: warn on unknown `slot` keys or invalid size tokens.
 
 #### 4) Runtime Editor (MVP)
 

--- a/@guidogerb/components/ui/src/responsive-slot/index.d.ts
+++ b/@guidogerb/components/ui/src/responsive-slot/index.d.ts
@@ -153,6 +153,20 @@ export function useResponsiveSlotSize(
   overrides?: SlotSizeOverrides | 'content',
 ): ResponsiveSlotSize
 
+export interface ResolveResponsiveSlotSizeOptions {
+  slot: string
+  breakpoint: BreakpointKey
+  registry?: Registry
+  overrides?: SlotSizeOverrides | 'content'
+  tokenResolver?: (tokenName: string) => string | number | undefined | null
+  inheritedSizes?: SlotSizeOverrides
+  fallbackBreakpoint?: BreakpointKey
+}
+
+export function resolveResponsiveSlotSize(
+  options: ResolveResponsiveSlotSizeOptions,
+): Omit<ResponsiveSlotSize, 'breakpoint'>
+
 export function useResponsiveSlotMeta(slot: string): SlotMeta
 
 export function useResponsiveSlotInstance(): ResponsiveSlotInstance | null

--- a/@guidogerb/components/ui/src/responsive-slot/index.js
+++ b/@guidogerb/components/ui/src/responsive-slot/index.js
@@ -4,6 +4,7 @@ export {
   useResponsiveSlotSize,
   useResponsiveSlotMeta,
   useResponsiveSlotInstance,
+  resolveResponsiveSlotSize,
   responsiveSlotBreakpoints,
   baseResponsiveSlots,
   ResponsiveSlot as GuidoGerbUI_Container,


### PR DESCRIPTION
## Summary
- add a public `resolveResponsiveSlotSize` helper and reuse it inside `useResponsiveSlotSize`
- warn once in development when responsive slot size tokens are missing and mark the spec tasks complete
- export the helper through the responsive-slot entry points and extend the Vitest suite to cover the new helper and warnings

## Testing
- pnpm --filter @guidogerb/components-ui test

------
https://chatgpt.com/codex/tasks/task_e_68d3764f56c88324b3b5bddfff626d5a