### PR TITLE
Add breakpoint metadata and instance-aware slot sizing hook

### DIFF
--- a/@guidogerb/components/ui/GuidoGerbUI_Container.spec.md
+++ b/@guidogerb/components/ui/GuidoGerbUI_Container.spec.md
@@ -459,10 +459,10 @@ src/
 #### 2) Breakpoints & Sizing
 
 - [x] Build `useBreakpointKey()` with `matchMedia` subscriptions and cleanup.
-- [ ] Add SSR/SSG default fallback support via provider prop.
+- [x] Add SSR/SSG default fallback support via provider prop.
 - [x] Build `resolveSizes(slotKey, bp, overrides)` with deep merge + fallbacks.
 - [x] Implement double‑buffered CSS variable algorithm and atomic flip.
-- [ ] Expose `useResponsiveSlotSize()` hook returning resolved sizes + active breakpoint.
+- [x] Expose `useResponsiveSlotSize()` hook returning resolved sizes + active breakpoint.
 
 #### 3) Wrapper Component
 

--- a/@guidogerb/components/ui/__tests__/ResponsiveSlot.test.jsx
+++ b/@guidogerb/components/ui/__tests__/ResponsiveSlot.test.jsx
@@ -142,6 +142,8 @@ describe('ResponsiveSlot', () => {
     expect(markup).toContain('data-slot-variant-label="Default"')
     expect(markup).toContain('data-slot-tags="commerce,grid"')
     expect(markup).toContain('data-slot-buffer="A"')
+    expect(markup).toContain('data-slot-default-breakpoint="lg"')
+    expect(markup).toContain('data-slot-breakpoint="lg"')
   })
 
   it('updates CSS variables when the active breakpoint changes', async () => {
@@ -176,6 +178,8 @@ describe('ResponsiveSlot', () => {
         expect(slot.style.getPropertyValue('--slot-min-block-size-B')).toBe('20rem')
         expect(slot.dataset.slotDefaultVariant).toBe('default')
         expect(slot.dataset.slotVariantLabel).toBe('Default')
+        expect(slot.dataset.slotDefaultBreakpoint).toBe('md')
+        expect(slot.dataset.slotBreakpoint).toBe('xs')
       })
 
       act(() => {
@@ -196,6 +200,7 @@ describe('ResponsiveSlot', () => {
         expect(slot.style.getPropertyValue('--slot-min-inline-size-B')).toBe('16rem')
         expect(slot.style.getPropertyValue('--slot-max-block-size-B')).toBe('26rem')
         expect(slot.style.getPropertyValue('--slot-min-block-size-B')).toBe('20rem')
+        expect(slot.dataset.slotBreakpoint).toBe('xl')
       })
     } finally {
       window.matchMedia = originalMatchMedia
@@ -384,6 +389,38 @@ describe('ResponsiveSlot', () => {
     expect(probe.dataset.block).toBe('28px')
     expect(probe.dataset.maxInline).toBe('30rem')
     expect(probe.dataset.breakpoint).toBe('xl')
+  })
+
+  it('prefers instance sizing when the hook is used within a rendered slot', async () => {
+    const originalMatchMedia = window.matchMedia
+    window.matchMedia = createMatchMedia(820)
+
+    function SizeProbe() {
+      const size = useResponsiveSlotSize('catalog.card')
+      return (
+        <div data-testid="size" data-inline={size.inline} data-breakpoint={size.breakpoint} />
+      )
+    }
+
+    try {
+      render(
+        <ResponsiveSlotProvider defaultBreakpoint="md">
+          <ResponsiveSlot
+            slot="catalog.card"
+            sizes={{ md: { inline: '32rem', block: '30rem' } }}
+            data-testid="slot-instance"
+          >
+            <SizeProbe />
+          </ResponsiveSlot>
+        </ResponsiveSlotProvider>,
+      )
+
+      const probe = await screen.findByTestId('size')
+      expect(probe.dataset.inline).toBe('32rem')
+      expect(probe.dataset.breakpoint).toBe('md')
+    } finally {
+      window.matchMedia = originalMatchMedia
+    }
   })
 
   it('inherits parent slot sizing when inherit is enabled', () => {

--- a/@guidogerb/components/ui/__tests__/ResponsiveSlot.visual.test.jsx
+++ b/@guidogerb/components/ui/__tests__/ResponsiveSlot.visual.test.jsx
@@ -47,7 +47,9 @@ describe('ResponsiveSlot visual baselines', () => {
       <div
         data-design-component="Catalog / Card"
         data-design-node="0:1"
+        data-slot-breakpoint="lg"
         data-slot-buffer="B"
+        data-slot-default-breakpoint="md"
         data-slot-default-variant="default"
         data-slot-description="Product tile used in merchandising grids and featured carousels."
         data-slot-key="catalog.card"
@@ -80,7 +82,9 @@ describe('ResponsiveSlot visual baselines', () => {
       <div
         data-design-component="Catalog / Card"
         data-design-node="0:1"
+        data-slot-breakpoint="xs"
         data-slot-buffer="B"
+        data-slot-default-breakpoint="md"
         data-slot-default-variant="default"
         data-slot-description="Product tile used in merchandising grids and featured carousels."
         data-slot-key="catalog.card"

--- a/@guidogerb/components/ui/src/ResponsiveSlot/ResponsiveSlot.jsx
+++ b/@guidogerb/components/ui/src/ResponsiveSlot/ResponsiveSlot.jsx
@@ -827,6 +827,14 @@ export function useResponsiveSlotSize(slot, overrides) {
     resolveToken: tokenResolver,
     defaultBreakpoint,
   } = useResponsiveSlotContext()
+  const instance = useContext(SlotInstanceContext)
+
+  const inheritedSizes = useMemo(() => {
+    if (!instance || instance.slot !== slot) {
+      return undefined
+    }
+    return instance.byBreakpoint
+  }, [instance, slot])
 
   const size = useMemo(
     () =>
@@ -836,9 +844,18 @@ export function useResponsiveSlotSize(slot, overrides) {
         registry,
         overrides,
         tokenResolver,
+        inheritedSizes,
         fallbackBreakpoint: defaultBreakpoint,
       }),
-    [activeBreakpoint, defaultBreakpoint, overrides, registry, slot, tokenResolver],
+    [
+      activeBreakpoint,
+      defaultBreakpoint,
+      inheritedSizes,
+      overrides,
+      registry,
+      slot,
+      tokenResolver,
+    ],
   )
 
   return useMemo(
@@ -884,6 +901,7 @@ export function ResponsiveSlot({
     activeBreakpoint,
     breakpoints,
     resolveToken: tokenResolver,
+    defaultBreakpoint,
   } = useResponsiveSlotContext()
   const parentContext = useContext(SlotInstanceContext)
   const slotRef = useRef(null)
@@ -1070,10 +1088,18 @@ export function ResponsiveSlot({
   const variantName = variantFromEditing ?? defaultVariant
   const propsPayload = editingProps
 
+  const normalizedDefaultBreakpoint = normalizeBreakpointKey(defaultBreakpoint)
+  const normalizedActiveBreakpoint = normalizeBreakpointKey(
+    activeBreakpoint,
+    normalizedDefaultBreakpoint,
+  )
+
   const datasetProps = {
     'data-slot-key': slot,
     'data-slot-variant': variantName,
     'data-slot-default-variant': defaultVariant,
+    'data-slot-default-breakpoint': normalizedDefaultBreakpoint,
+    'data-slot-breakpoint': normalizedActiveBreakpoint,
   }
   if (meta?.label) datasetProps['data-slot-label'] = meta.label
   if (meta?.description) datasetProps['data-slot-description'] = meta.description


### PR DESCRIPTION
## Summary
- annotate responsive slot markup with default and active breakpoint metadata so SSR fallback and hydration have deterministic breakpoints
- teach `useResponsiveSlotSize` to prefer the rendered slot instance sizes before falling back to the registry
- expand responsive slot test coverage and mark the corresponding implementation tasks complete

## Testing
- pnpm --filter @guidogerb/components-ui test

------
https://chatgpt.com/codex/tasks/task_e_68d37b5ea55483249c0bc836ad38aa69