### PR TITLE
Add pagination item limit and error request IDs

### DIFF
--- a/@guidogerb/components/api-client/index.d.ts
+++ b/@guidogerb/components/api-client/index.d.ts
@@ -29,7 +29,7 @@ export interface Logger {
   warn?: (...args: unknown[]) => void
 }
 
-export type PaginateStopReason = 'exhausted' | 'max-pages' | 'duplicate-cursor'
+export type PaginateStopReason = 'exhausted' | 'max-pages' | 'duplicate-cursor' | 'max-items'
 
 export interface PaginatedPageContext<TParams extends Record<string, any> = Record<string, any>> {
   page: number
@@ -63,6 +63,7 @@ export interface CollectPaginatedOptions<
   onPage?: (result: TResult, context: PaginatedPageContext<TParams>) => void | Promise<void>
   accumulateItems?: boolean
   stopOnDuplicateCursor?: boolean
+  maxItems?: number
 }
 
 export interface CollectPaginatedResult<
@@ -142,6 +143,7 @@ export interface NormalizedApiError {
   cause?: unknown
   isApiError: boolean
   original: unknown
+  requestId: string | null
 }
 
 export declare function normalizeApiError(error: unknown): NormalizedApiError

--- a/@guidogerb/components/api-client/tasks.md
+++ b/@guidogerb/components/api-client/tasks.md
@@ -5,3 +5,5 @@
 | Document client factory usage     | 2025-09-19  | 2025-09-19      | 2025-09-19    | complete | Clarified expected options for `createClient` including auth token hooks and base URL configuration. |
 | Implement POST/PUT retry strategy | 2025-09-19  | 2025-09-20      | 2025-09-20    | complete | Extend the transport wrapper with exponential backoff for idempotent writes and timeout handling.    |
 | Publish TypeScript definitions    | 2025-09-19  | 2025-09-20      | 2025-09-20    | complete | Generate `.d.ts` files or migrate sources so consumers receive typed API responses.                  |
+| Add max-items guard to pagination | 2025-09-30  | 2025-09-30      | 2025-09-30    | complete | Introduced a `maxItems` option for `collectPaginatedResults` so bulk fetches can stop once a desired record count is reached. |
+| Surface request IDs in errors     | 2025-09-30  | 2025-09-30      | 2025-09-30    | complete | `normalizeApiError` now extracts request identifiers from headers and payloads to improve trace correlation in logs.          |


### PR DESCRIPTION
## Summary
- add an optional `maxItems` guard to `collectPaginatedResults` so pagination can stop once a target count is collected and update the TypeScript declarations
- capture request identifiers in `normalizeApiError` by reading headers/payload hints and expose the metadata via the public types

## Testing
- `pnpm --filter @guidogerb/components-api test -- --reporter=basic`

------
https://chatgpt.com/codex/tasks/task_e_68d38be393d883249e1f77cb8524c831