### PR TITLE
Add landing and navigation vitest coverage for tenant sites

### DIFF
--- a/docs/test/tasks-test.md
+++ b/docs/test/tasks-test.md
@@ -27,8 +27,10 @@ This backlog enumerates every application-facing workspace in the monorepo and c
 | ---------------------------------- | -------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
 | `websites/garygerber.com`          | ✅ App-level tests cover hero content, rehearsal room wiring, and header navigation scroll handling.                 | Follow up with router-based smoke tests (newsletter form, error states) once public/protected routes are implemented. |
 | `websites/guidogerbpublishing.com` | ✅ App-level tests validate the publishing hero content, portal guard wiring, and header navigation scroll handling. | Plan follow-up coverage for catalog submission flows once routes are introduced.                                      |
-| `websites/picklecheeze.com`        | _None_                                                                                                               | Add snapshot/interaction tests for unique theming once components exist.                                              |
-| `websites/this-is-my-story.org`    | _None_                                                                                                               | Add tests for story navigation flows and ensure 404 handling works.                                                   |
+| `websites/picklecheeze.com`        | ✅ Landing section tests cover fermentation hero copy, newsletter interactions, and partner hub wiring.
+                            | Expand coverage to include portal analytics events once auth-driven dashboards go live.
+| `websites/this-is-my-story.org`    | ✅ App and component tests exercise navigation flows, maintenance notices, and storyteller portal wiring.
+                            | Add regression coverage for future story submission flows and content feeds.
 | `websites/stream4cloud.com`        | _None_                                                                                                               | Cover the landing page hero, CTA wiring, and route guards once the app shell exists.                                  |
 
 ## Cross-cutting infrastructure

--- a/websites/picklecheeze.com/src/website-components/landing-sections/__tests__/LandingSections.test.jsx
+++ b/websites/picklecheeze.com/src/website-components/landing-sections/__tests__/LandingSections.test.jsx
@@ -1,0 +1,106 @@
+import { render, screen, within } from '@testing-library/react'
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const useAuthMock = vi.hoisted(() =>
+  vi.fn(() => ({ isAuthenticated: true, user: { profile: { name: 'Partner Tester', email: 'partner@example.com' } } })),
+)
+
+vi.mock('@guidogerb/components-auth', () => ({
+  __esModule: true,
+  Auth: ({ children, ...props }) => (
+    <div data-testid="auth-provider" data-props={JSON.stringify(props)}>
+      {children}
+    </div>
+  ),
+  useAuth: () => useAuthMock(),
+}))
+
+let FermentationHeroSection
+let NewsletterSignupSection
+let PartnerHubSection
+
+beforeAll(async () => {
+  vi.resetModules()
+  ;({ FermentationHeroSection } = await import('../FermentationHeroSection.jsx'))
+  ;({ NewsletterSignupSection } = await import('../NewsletterSignupSection.jsx'))
+  ;({ PartnerHubSection } = await import('../PartnerHubSection.jsx'))
+})
+
+afterAll(() => {
+  vi.resetModules()
+})
+
+describe('PickleCheeze landing sections', () => {
+  beforeEach(() => {
+    useAuthMock.mockClear()
+    useAuthMock.mockReturnValue({
+      isAuthenticated: true,
+      user: { profile: { name: 'Partner Tester', email: 'partner@example.com' } },
+    })
+  })
+
+  it('renders fermentation hero branding with highlight metrics', () => {
+    render(<FermentationHeroSection />)
+
+    const heading = screen.getByRole('heading', {
+      level: 1,
+      name: /PickleCheeze cultures vegetables and plant-based cheeze/i,
+    })
+
+    const hero = heading.closest('section')
+    expect(hero).not.toBeNull()
+    expect(hero).toHaveClass('hero')
+    expect(
+      within(hero ?? document.body).getByText(
+        /We ferment in small batches using hyper-local produce/i,
+      ),
+    ).toBeInTheDocument()
+
+    const highlights = within(hero ?? document.body).getAllByRole('definition')
+    expect(highlights).toHaveLength(3)
+    const metrics = within(hero ?? document.body).getAllByRole('term')
+    expect(metrics).toHaveLength(3)
+    expect(highlights[0]).toHaveTextContent('Average ferment time')
+    expect(metrics[0]).toHaveTextContent('48 hrs')
+  })
+
+  it('prevents default navigation when submitting the newsletter form', () => {
+    render(<NewsletterSignupSection />)
+
+    const form = screen.getByRole('form', { name: /newsletter sign up/i })
+    const email = within(form).getByRole('textbox', { name: /email address/i })
+    const submit = within(form).getByRole('button', { name: /notify me/i })
+
+    expect(email).toHaveAttribute('placeholder', 'you@example.com')
+    expect(submit).toHaveAttribute('type', 'submit')
+
+    const submitEvent = new Event('submit', { bubbles: true, cancelable: true })
+    form.dispatchEvent(submitEvent)
+    expect(submitEvent.defaultPrevented).toBe(true)
+  })
+
+  it('wires the partner hub through the protected welcome experience', () => {
+    const logoutUri = '/auth/logout'
+    render(
+      <PartnerHubSection logoutUri={logoutUri} />,
+    )
+
+    const sectionHeading = screen.getByRole('heading', { level: 2, name: /partner pantry/i })
+    const section = sectionHeading.closest('section')
+    expect(section).not.toBeNull()
+    expect(section).toHaveClass('protected')
+    expect(
+      within(section ?? document.body).getByText(
+        /Chefs, buyers, and collaborators can review seasonal availability/i,
+      ),
+    ).toBeInTheDocument()
+
+    const authNode = screen.getByTestId('auth-provider')
+    expect(authNode).toBeInTheDocument()
+    const authProps = JSON.parse(authNode.getAttribute('data-props') ?? '{}')
+    expect(authProps.logoutUri).toBe(logoutUri)
+    expect(screen.getByText(/Welcome back, Partner Tester!/i)).toBeInTheDocument()
+    expect(screen.getByText('Signed in as partner@example.com')).toBeInTheDocument()
+    expect(useAuthMock).toHaveBeenCalled()
+  })
+})

--- a/websites/this-is-my-story.org/src/__tests__/NavigationFlows.test.jsx
+++ b/websites/this-is-my-story.org/src/__tests__/NavigationFlows.test.jsx
@@ -1,0 +1,78 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockUseAuth, navigateSpy } = vi.hoisted(() => ({
+  mockUseAuth: vi.fn(),
+  navigateSpy: vi.fn(),
+}))
+
+vi.mock('@guidogerb/components-auth', () => ({
+  __esModule: true,
+  useAuth: () => mockUseAuth(),
+}))
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom')
+  return {
+    ...actual,
+    useNavigate: () => navigateSpy,
+  }
+})
+
+vi.mock('../App.css', () => ({}), { virtual: true })
+vi.mock('../assets/story-circle.svg', () => ({ default: 'story-circle.svg' }))
+
+async function renderApp(initialPath = '/') {
+  window.history.replaceState({}, '', initialPath)
+
+  const module = await import('../App.jsx')
+  const App = module.default
+  return render(<App />)
+}
+
+describe('This-Is-My-Story navigation flows', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    mockUseAuth.mockReset()
+    mockUseAuth.mockReturnValue({ isAuthenticated: false })
+    navigateSpy.mockReset()
+  })
+
+  it('prevents default navigation and redirects home from the not-found route', async () => {
+    await renderApp('/missing')
+
+    const primaryAction = await screen.findByRole('link', {
+      name: 'Return to storyteller hub',
+    })
+
+    const clickEvent = new MouseEvent('click', { bubbles: true, cancelable: true })
+    fireEvent(primaryAction, clickEvent)
+
+    expect(navigateSpy).toHaveBeenCalledWith('/')
+    expect(clickEvent.defaultPrevented).toBe(true)
+  })
+
+  it('redirects visitors back to the landing page from maintenance notices', async () => {
+    await renderApp('/maintenance')
+
+    const maintenanceAction = await screen.findByRole('link', {
+      name: 'Return to storyteller hub',
+    })
+
+    const clickEvent = new MouseEvent('click', { bubbles: true, cancelable: true })
+    fireEvent(maintenanceAction, clickEvent)
+
+    expect(navigateSpy).toHaveBeenCalledWith('/')
+    expect(clickEvent.defaultPrevented).toBe(true)
+  })
+
+  it('exposes hero navigation anchors that link to in-page sections', async () => {
+    await renderApp('/')
+
+    const explorePrograms = await screen.findByRole('link', { name: 'Explore our programs' })
+    const joinStudio = await screen.findByRole('link', { name: 'Join the storyteller studio' })
+
+    expect(explorePrograms).toHaveAttribute('href', '#programs')
+    expect(joinStudio).toHaveAttribute('href', '#studio')
+  })
+})


### PR DESCRIPTION
## Summary
- add PickleCheeze landing-section tests that verify hero metrics, newsletter submission behaviour, and protected partner hub wiring
- add This-Is-My-Story navigation-flow tests that mock the router navigate helper and assert maintenance/not-found redirects plus hero anchors
- document the updated coverage in the testing backlog

## Testing
- pnpm --filter websites-picklecheeze test
- pnpm --filter websites-this-is-my-story exec vitest run --config ../../vitest.config.mjs

------
https://chatgpt.com/codex/tasks/task_e_68d3908c087c8324a65f7f7fc5f5fb56