### PR TITLE
feat(ui): add GuidoGerbUI_Container wrapper and coverage

### DIFF
--- a/@guidogerb/components/ui/__tests__/GuidoGerbUI_Container.test.jsx
+++ b/@guidogerb/components/ui/__tests__/GuidoGerbUI_Container.test.jsx
@@ -1,0 +1,85 @@
+import { render, screen, waitFor } from '@testing-library/react'
+
+import {
+  GuidoGerbUI_Container,
+  ResponsiveSlotProvider,
+} from '../src/responsive-slot/index.js'
+
+describe('GuidoGerbUI_Container', () => {
+  it('respects custom element rendering and default role', () => {
+    render(
+      <ResponsiveSlotProvider>
+        <GuidoGerbUI_Container slot="catalog.card" as="section" data-testid="container">
+          <span>Content</span>
+        </GuidoGerbUI_Container>
+      </ResponsiveSlotProvider>,
+    )
+
+    const element = screen.getByTestId('container')
+    expect(element.tagName).toBe('SECTION')
+    expect(element).toHaveAttribute('role', 'presentation')
+    expect(element.dataset.slotKey).toBe('catalog.card')
+  })
+
+  it('applies overflow and min/max overrides to the CSS variable contract', async () => {
+    render(
+      <ResponsiveSlotProvider defaultBreakpoint="md">
+        <GuidoGerbUI_Container
+          slot="catalog.card"
+          data-testid="sized"
+          overflow="visible"
+          sizes={{
+            md: {
+              inline: '30rem',
+              block: '28rem',
+              maxInline: '32rem',
+              maxBlock: '34rem',
+              minInline: '24rem',
+              minBlock: '20rem',
+            },
+          }}
+        />
+      </ResponsiveSlotProvider>,
+    )
+
+    const element = await screen.findByTestId('sized')
+
+    await waitFor(() => {
+      expect(element.style.getPropertyValue('--slot-inline')).toBe('30rem')
+      expect(element.style.getPropertyValue('--slot-max-inline')).toBe('32rem')
+      expect(element.style.getPropertyValue('--slot-min-inline')).toBe('24rem')
+      expect(element.style.getPropertyValue('--slot-block')).toBe('28rem')
+      expect(element.style.getPropertyValue('--slot-max-block')).toBe('34rem')
+      expect(element.style.getPropertyValue('--slot-min-block')).toBe('20rem')
+    })
+
+    expect(element.style.overflow).toBe('visible')
+  })
+
+  it('inherits resolved sizes from parent containers when inherit is true', async () => {
+    render(
+      <ResponsiveSlotProvider defaultBreakpoint="lg">
+        <GuidoGerbUI_Container
+          slot="catalog.card"
+          data-testid="parent"
+          sizes={{ lg: { inline: '36rem', block: '30rem' } }}
+        >
+          <GuidoGerbUI_Container slot="catalog.card" inherit data-testid="child" />
+        </GuidoGerbUI_Container>
+      </ResponsiveSlotProvider>,
+    )
+
+    const parent = await screen.findByTestId('parent')
+    const child = await screen.findByTestId('child')
+
+    await waitFor(() => {
+      expect(child.style.getPropertyValue('--slot-inline')).toBe(
+        parent.style.getPropertyValue('--slot-inline'),
+      )
+      expect(child.style.getPropertyValue('--slot-block')).toBe(
+        parent.style.getPropertyValue('--slot-block'),
+      )
+    })
+  })
+})
+

--- a/@guidogerb/components/ui/__tests__/responsive-slot.module.test.jsx
+++ b/@guidogerb/components/ui/__tests__/responsive-slot.module.test.jsx
@@ -9,20 +9,30 @@ import {
 } from '../src/responsive-slot/index.js'
 
 describe('responsive-slot module exports', () => {
-  it('aliases GuidoGerbUI_Container to the existing ResponsiveSlot component', () => {
-    expect(ResponsiveSlot).toBe(GuidoGerbUI_Container)
-
+  it('renders equivalent markup via GuidoGerbUI_Container and ResponsiveSlot', () => {
     render(
       <ResponsiveSlotProvider defaultBreakpoint="lg">
-        <GuidoGerbUI_Container slot="catalog.card" data-testid="slot">
-          <div>Content</div>
-        </GuidoGerbUI_Container>
+        <div>
+          <GuidoGerbUI_Container slot="catalog.card" data-testid="container">
+            <div>Container child</div>
+          </GuidoGerbUI_Container>
+          <ResponsiveSlot slot="catalog.card" data-testid="legacy">
+            <div>Legacy child</div>
+          </ResponsiveSlot>
+        </div>
       </ResponsiveSlotProvider>,
     )
 
-    const slot = screen.getByTestId('slot')
-    expect(slot.dataset.slotKey).toBe('catalog.card')
-    expect(slot.dataset.slotLabel).toBe('Catalog Card')
+    const container = screen.getByTestId('container')
+    const legacy = screen.getByTestId('legacy')
+
+    expect(container.dataset.slotKey).toBe('catalog.card')
+    expect(container.dataset.slotLabel).toBe('Catalog Card')
+    expect(container.dataset.slotDefaultVariant).toBe('default')
+
+    expect(legacy.dataset.slotKey).toBe(container.dataset.slotKey)
+    expect(legacy.dataset.slotLabel).toBe(container.dataset.slotLabel)
+    expect(legacy.dataset.slotDefaultVariant).toBe(container.dataset.slotDefaultVariant)
   })
 
   it('exposes breakpoint descriptors and base presets', () => {

--- a/@guidogerb/components/ui/package.json
+++ b/@guidogerb/components/ui/package.json
@@ -29,6 +29,7 @@
     "src/ResponsiveSlot/editing/SlotEditorOverlay.jsx",
     "src/ResponsiveSlot/editing/useSlotEditing.js",
     "src/ResponsiveSlot/editing/localDraftStorage.js",
+    "src/responsive-slot/GuidoGerbUI_Container.jsx",
     "src/responsive-slot/index.js",
     "src/responsive-slot/index.d.ts"
   ],

--- a/@guidogerb/components/ui/src/responsive-slot/GuidoGerbUI_Container.jsx
+++ b/@guidogerb/components/ui/src/responsive-slot/GuidoGerbUI_Container.jsx
@@ -1,0 +1,16 @@
+import { ResponsiveSlot } from '../ResponsiveSlot/ResponsiveSlot.jsx'
+
+const DEFAULT_OVERFLOW = 'hidden auto'
+
+/**
+ * Thin wrapper around the existing ResponsiveSlot implementation that exposes the
+ * GuidoGerb UI Container API described in the spec. It preserves the default
+ * overflow behaviour, forwards sizing props, and leaves room for future
+ * enhancements without forcing consumers to migrate immediately.
+ */
+export function GuidoGerbUI_Container({ overflow = DEFAULT_OVERFLOW, ...props }) {
+  return <ResponsiveSlot overflow={overflow} {...props} />
+}
+
+GuidoGerbUI_Container.displayName = 'GuidoGerbUI_Container'
+

--- a/@guidogerb/components/ui/src/responsive-slot/index.d.ts
+++ b/@guidogerb/components/ui/src/responsive-slot/index.d.ts
@@ -187,7 +187,9 @@ export function GuidoGerbUI_Container<E extends React.ElementType = 'div'>(
   props: GuidoGerbUI_ContainerProps<E>,
 ): JSX.Element
 
-export { GuidoGerbUI_Container as ResponsiveSlot }
+export function ResponsiveSlot<E extends React.ElementType = 'div'>(
+  props: GuidoGerbUI_ContainerProps<E>,
+): JSX.Element
 
 export const responsiveSlotBreakpoints: ReadonlyArray<ResponsiveSlotBreakpoint>
 

--- a/@guidogerb/components/ui/src/responsive-slot/index.js
+++ b/@guidogerb/components/ui/src/responsive-slot/index.js
@@ -7,10 +7,10 @@ export {
   resolveResponsiveSlotSize,
   responsiveSlotBreakpoints,
   baseResponsiveSlots,
-  ResponsiveSlot as GuidoGerbUI_Container,
   ResponsiveSlot,
 } from '../ResponsiveSlot/ResponsiveSlot.jsx'
 
 export { EditModeProvider, useEditMode } from '../ResponsiveSlot/editing/EditModeContext.jsx'
 export { JsonEditor } from '../ResponsiveSlot/editing/JsonEditor.jsx'
 export { SlotEditorOverlay } from '../ResponsiveSlot/editing/SlotEditorOverlay.jsx'
+export { GuidoGerbUI_Container } from './GuidoGerbUI_Container.jsx'


### PR DESCRIPTION
## Summary
- expose a dedicated `GuidoGerbUI_Container` wrapper and export it alongside the legacy ResponsiveSlot implementation
- align the responsive-slot type definitions and package manifest with the new wrapper
- add focused tests that exercise the wrapper API and update the module export expectations

## Testing
- pnpm --filter @guidogerb/components-ui test

------
https://chatgpt.com/codex/tasks/task_e_68d3ade75548832486302de3f4474ebe