### PR TITLE
Handle alternate SITES declarations in AddCF-Tenant script

### DIFF
--- a/infra/ps1/AddCF-Tenant.ps1
+++ b/infra/ps1/AddCF-Tenant.ps1
@@ -500,8 +500,10 @@ function Update-SyncSitesScript {
     $lines = Get-Content -Path $scriptPath
 
     $sitesStart = -1
+    $sitesPattern = '^\s*(?:declare\s+-a\s+|readonly\s+|local\s+-r\s+|local\s+)?SITES\s*=\s*\('
+
     for ($i = 0; $i -lt $lines.Count; $i++) {
-        if ($lines[$i] -match '^SITES=\(') {
+        if ($lines[$i] -match $sitesPattern) {
             $sitesStart = $i
             break
         }


### PR DESCRIPTION
## Summary
- allow the AddCF-Tenant PowerShell script to find the SITES array even when qualifiers such as `declare -a` or `readonly` are used in sync-sites.sh

## Testing
- pnpm test:infra

------
https://chatgpt.com/codex/tasks/task_e_68d48de456048324832a4e340bdaf50c