### PR TITLE
Fix PowerShell regex for site entries

### DIFF
--- a/infra/ps1/AddCF-Tenant.ps1
+++ b/infra/ps1/AddCF-Tenant.ps1
@@ -521,8 +521,10 @@ function Update-SyncSitesScript {
     }
 
     $siteEntries = @()
+    $quote = [char]34
+    $pattern = "$quote([^$quote]+)$quote"
     for ($i = $sitesStart + 1; $i -lt $sitesEnd; $i++) {
-        if ($lines[$i] -match '"([^"]+)"') {
+        if ($lines[$i] -match $pattern) {
             $siteEntries += $matches[1]
         }
     }


### PR DESCRIPTION
## Summary
- adjust AddCF-Tenant.ps1 to build the SITES parsing regex via character constants to avoid PowerShell parser errors

## Testing
- pnpm run test:infra

------
https://chatgpt.com/codex/tasks/task_e_68d4938a5a0483249a1cf66ffa289aea