### PR TITLE
Fix regex pattern in AddCF tenant script

### DIFF
--- a/infra/ps1/AddCF-Tenant.ps1
+++ b/infra/ps1/AddCF-Tenant.ps1
@@ -521,8 +521,7 @@ function Update-SyncSitesScript {
     }
 
     $siteEntries = @()
-    $quote = [char]34
-    $pattern = "$quote([^$quote]+)$quote"
+    $pattern = '"([^"]+)"'
     for ($i = $sitesStart + 1; $i -lt $sitesEnd; $i++) {
         if ($lines[$i] -match $pattern) {
             $siteEntries += $matches[1]


### PR DESCRIPTION
## Summary
- replace the interpolated regex pattern in AddCF-Tenant.ps1 with a literal double-quote matcher to avoid PowerShell parsing errors

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d4957710d48324b50c75f935180e3b