### PR TITLE
Fix infra test script recursion

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "dev": "pnpm -r --parallel dev",
     "lint": "pnpm -r lint",
     "test": "cross-env NODE_OPTIONS=--max-old-space-size=4096 pnpm -r docs/test && pnpm -r test",
-    "test:infra": "vitest run infra/scripts/__tests__ && pnpm run test:infra",
+    "test:infra": "vitest run infra/scripts/__tests__",
     "build:site:guidogerbpublishing": "pnpm --filter websites-guidogerbpublishing build",
     "build:site:stream4cloud": "pnpm --filter websites-stream4cloud build",
     "build:site:garygerber": "pnpm --filter websites-garygerber build",


### PR DESCRIPTION
## Summary
- remove the recursive call in the root test:infra script so it only runs the Vitest suite once

## Testing
- CI=1 pnpm test
- CI=1 pnpm test:infra

------
https://chatgpt.com/codex/tasks/task_e_68d5421a6934832483bc1dae54fc16c8