### PR TITLE
Document garygerber automation touchpoints

### DIFF
--- a/websites/garygerber.com/README.md
+++ b/websites/garygerber.com/README.md
@@ -46,5 +46,22 @@ pnpm --filter websites/garygerber.com build
 pnpm --filter websites/garygerber.com preview
 ```
 
+## Automation touch points
+
+Automation and provisioning scripts still rely on hard-coded references to this
+tenant. The tracked inventory lives in
+[`automation-touchpoints.json`](./automation-touchpoints.json) and includes:
+
+- **Root scripts** — `package.json` exposes `build:site:garygerber` and
+  `dev:site:garygerber` commands so CI can target this workspace directly.
+- **Site configuration** — `vite.config.js`, `generate-sitemap.mjs`, and the
+  published `public/sitemap.xml` embed the production domain and local dev
+  hostnames.
+- **Local development** — the CloudFront/S3 simulators (`infra/local-dev/*`) and
+  sync scripts restrict allowed hosts to `local.garygerber.com`.
+- **Secrets and runbooks** — `docs/CICD.md` and the seeded
+  `GARYGERBER_COM_VITE_ENV-secrets` file document the required environment
+  variables for deployments.
+
 Upcoming work—including rehearsal portal expansion and localized error routes—is tracked in
 [`tasks.md`](./tasks.md).

--- a/websites/garygerber.com/automation-touchpoints.json
+++ b/websites/garygerber.com/automation-touchpoints.json
@@ -1,0 +1,44 @@
+{
+  "domain": "garygerber.com",
+  "workspaceSlug": "garygerber",
+  "touchPoints": [
+    {
+      "category": "root-scripts",
+      "check": "domain",
+      "paths": [
+        "package.json"
+      ],
+      "notes": "Root scripts reference the tenant workspace for build/dev commands."
+    },
+    {
+      "category": "site-config",
+      "check": "domain",
+      "paths": [
+        "websites/garygerber.com/vite.config.js",
+        "websites/garygerber.com/generate-sitemap.mjs",
+        "websites/garygerber.com/public/sitemap.xml"
+      ],
+      "notes": "Tenant bundler, sitemap tooling, and generated assets embed the production domain."
+    },
+    {
+      "category": "local-development",
+      "check": "domain",
+      "paths": [
+        "infra/local-dev/cloudfront/nginx.conf",
+        "infra/local-dev/s3/nginx.conf",
+        "infra/local-dev/scripts/sync-sites.sh",
+        "infra/local-dev/README.md"
+      ],
+      "notes": "Local CloudFront/S3 simulators and sync scripts hard-code the tenant hostnames."
+    },
+    {
+      "category": "secrets",
+      "check": "domain",
+      "paths": [
+        "docs/CICD.md",
+        "websites/garygerber.com/GARYGERBER_COM_VITE_ENV-secrets"
+      ],
+      "notes": "Deployment runbooks and seed secret files encode the tenant domain."
+    }
+  ]
+}

--- a/websites/garygerber.com/src/__tests__/automationTouchpoints.test.js
+++ b/websites/garygerber.com/src/__tests__/automationTouchpoints.test.js
@@ -1,0 +1,42 @@
+// @vitest-environment node
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const repoRoot = fileURLToPath(new URL('../../../../', import.meta.url))
+
+describe('garygerber.com automation touchpoints', () => {
+  const automationConfigPath = join(repoRoot, 'websites/garygerber.com/automation-touchpoints.json')
+  const automationConfig = JSON.parse(readFileSync(automationConfigPath, 'utf8'))
+
+  it('tracks domain metadata and ensures listed files exist', () => {
+    const { domain, workspaceSlug, touchPoints } = automationConfig
+
+    expect(domain).toBe('garygerber.com')
+    expect(workspaceSlug).toBe('garygerber')
+    expect(Array.isArray(touchPoints)).toBe(true)
+    expect(touchPoints.length).toBeGreaterThan(0)
+
+    for (const touchPoint of touchPoints) {
+      expect(Array.isArray(touchPoint.paths)).toBe(true)
+      expect(touchPoint.paths.length).toBeGreaterThan(0)
+
+      for (const relativePath of touchPoint.paths) {
+        const absolutePath = join(repoRoot, relativePath)
+        const contents = readFileSync(absolutePath, 'utf8')
+
+        switch (touchPoint.check) {
+          case 'domain':
+            expect(contents).toContain(domain)
+            break
+          case 'slug':
+            expect(contents).toMatch(new RegExp(`\\b${workspaceSlug}\\b`, 'i'))
+            break
+          default:
+            throw new Error(`Unknown touchpoint check '${touchPoint.check}' for ${relativePath}`)
+        }
+      }
+    }
+  })
+})

--- a/websites/garygerber.com/tasks.md
+++ b/websites/garygerber.com/tasks.md
@@ -5,4 +5,4 @@
 | Update README for artist site          | 2025-09-19  | 2025-09-19      | 2025-09-19    | complete | Documented navigation sections, rehearsal portal usage, and local dev steps for the artist site.            |
 | Build rehearsal resources landing page | 2025-09-19  | 2025-09-23      | 2025-09-23    | complete | Expand the protected area with rehearsal notes, stage plots, and scheduling widgets.                        |
 | Implement localized not-found route    | 2025-09-19  | 2025-09-23      | 2025-09-23    | complete | Add a branded 404 page with contact options for presenters and collaborators.                               |
-| Capture automation touch points        | 2025-09-30  | 2025-09-30      | -             | planned  | Inventory garygerber.com-specific wiring (scripts, workflows, env files) needed for `AddCF-Tenant` support. |
+| Capture automation touch points        | 2025-09-30  | 2025-10-07      | 2025-10-07    | complete | Documented tenant-specific hosts, scripts, and secrets in `automation-touchpoints.json` and added regression tests. |


### PR DESCRIPTION
## Summary
- record garygerber.com automation touch points in a JSON manifest and surface the highlights in the tenant README
- add a vitest that loads the manifest to verify each referenced file exists and still embeds the tenant domain
- mark the automation backlog item for garygerber.com as complete with the new coverage details

## Testing
- pnpm --filter websites-garygerber test

------
https://chatgpt.com/codex/tasks/task_e_68d5e508e4c0832499396606e4d334b4