### PR TITLE
Track guidogerbpublishing.com automation touch points

### DIFF
--- a/websites/guidogerbpublishing.com/README.md
+++ b/websites/guidogerbpublishing.com/README.md
@@ -48,5 +48,21 @@ pnpm --filter websites/guidogerbpublishing.com build
 pnpm --filter websites/guidogerbpublishing.com preview
 ```
 
+## Automation touch points
+
+Automation and provisioning scripts still reference this tenant directly. The tracked
+inventory lives in [`automation-touchpoints.json`](./automation-touchpoints.json) and includes:
+
+- **Root scripts** — `package.json` exposes `build:site:guidogerbpublishing` and
+  `dev:site:guidogerbpublishing` entries so CI and local tooling can target the workspace.
+- **Site configuration** — `vite.config.js`, `generate-sitemap.mjs`, and the published
+  `public/sitemap.xml` embed the production domain alongside local development hosts.
+- **Local development** — CloudFront/S3 simulators and sync scripts in `infra/local-dev/*`
+  enumerate the `guidogerbpublishing.com` hostnames that must be templated during scaffolding.
+- **Secrets and runbooks** — `docs/CICD.md` and the seeded
+  `GUIDOGERBPUBLISHING_VITE_ENV-secrets` document the required environment variables.
+- **Deployment helpers** — the `scripts/deploy-reference.mjs` workflow depends on the
+  `guidogerbpublishing` workspace slug for build orchestration.
+
 See [`tasks.md`](./tasks.md) for outstanding work such as wiring CMS-driven content and building the
 partner portal route.

--- a/websites/guidogerbpublishing.com/automation-touchpoints.json
+++ b/websites/guidogerbpublishing.com/automation-touchpoints.json
@@ -1,0 +1,60 @@
+{
+  "domain": "guidogerbpublishing.com",
+  "workspaceSlug": "guidogerbpublishing",
+  "touchPoints": [
+    {
+      "category": "root-scripts",
+      "check": "domain",
+      "paths": [
+        "package.json"
+      ],
+      "notes": "Root scripts expose guidogerbpublishing.com-specific build and dev commands."
+    },
+    {
+      "category": "site-config",
+      "check": "domain",
+      "paths": [
+        "websites/guidogerbpublishing.com/vite.config.js",
+        "websites/guidogerbpublishing.com/generate-sitemap.mjs",
+        "websites/guidogerbpublishing.com/public/sitemap.xml"
+      ],
+      "notes": "Bundler and sitemap configuration embed the tenant domain and local hostnames."
+    },
+    {
+      "category": "local-development",
+      "check": "domain",
+      "paths": [
+        "infra/local-dev/cloudfront/nginx.conf",
+        "infra/local-dev/s3/nginx.conf",
+        "infra/local-dev/scripts/sync-sites.sh",
+        "infra/local-dev/README.md"
+      ],
+      "notes": "Local edge simulators and sync scripts enumerate the guidogerbpublishing.com hosts."
+    },
+    {
+      "category": "secrets",
+      "check": "domain",
+      "paths": [
+        "docs/CICD.md",
+        "websites/guidogerbpublishing.com/GUIDOGERBPUBLISHING_VITE_ENV-secrets"
+      ],
+      "notes": "Deployment runbooks and seed secret files encode the production domain."
+    },
+    {
+      "category": "deploy-scripts",
+      "check": "slug",
+      "paths": [
+        "websites/guidogerbpublishing.com/scripts/deploy-reference.mjs"
+      ],
+      "notes": "Reference deployment automation builds the workspace using the slug."
+    },
+    {
+      "category": "tenant-manifest",
+      "check": "slug",
+      "paths": [
+        "infra/ps1/tenant-manifest.json"
+      ],
+      "notes": "Tenant provisioning manifest records the workspace slug for generator tooling."
+    }
+  ]
+}

--- a/websites/guidogerbpublishing.com/src/__tests__/automationTouchpoints.test.js
+++ b/websites/guidogerbpublishing.com/src/__tests__/automationTouchpoints.test.js
@@ -1,0 +1,47 @@
+// @vitest-environment node
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const repoRoot = fileURLToPath(new URL('../../../../', import.meta.url))
+
+describe('guidogerbpublishing.com automation touchpoints', () => {
+  const automationConfigPath = join(
+    repoRoot,
+    'websites/guidogerbpublishing.com/automation-touchpoints.json',
+  )
+  const automationConfig = JSON.parse(readFileSync(automationConfigPath, 'utf8'))
+
+  it('tracks domain metadata and ensures listed files exist', () => {
+    const { domain, workspaceSlug, touchPoints } = automationConfig
+
+    expect(domain).toBe('guidogerbpublishing.com')
+    expect(workspaceSlug).toBe('guidogerbpublishing')
+    expect(Array.isArray(touchPoints)).toBe(true)
+    expect(touchPoints.length).toBeGreaterThan(0)
+
+    for (const touchPoint of touchPoints) {
+      expect(Array.isArray(touchPoint.paths)).toBe(true)
+      expect(touchPoint.paths.length).toBeGreaterThan(0)
+
+      for (const relativePath of touchPoint.paths) {
+        const absolutePath = join(repoRoot, relativePath)
+        const contents = readFileSync(absolutePath, 'utf8')
+
+        switch (touchPoint.check) {
+          case 'domain':
+            expect(contents).toContain(domain)
+            break
+          case 'slug':
+            expect(contents).toMatch(new RegExp(`\\b${workspaceSlug}\\b`, 'i'))
+            break
+          default:
+            throw new Error(
+              `Unknown touchpoint check '${touchPoint.check}' for ${relativePath}`,
+            )
+        }
+      }
+    }
+  })
+})

--- a/websites/guidogerbpublishing.com/tasks.md
+++ b/websites/guidogerbpublishing.com/tasks.md
@@ -5,4 +5,4 @@
 | Rewrite README for publishing tenant | 2025-09-19  | 2025-09-19      | 2025-09-19    | complete | Documented section navigation, partner use cases, and environment variables for the publishing portal.                   |
 | Wire marketing sections to CMS data  | 2025-09-19  | 2025-09-23      | 2025-09-23    | complete | Replace static copy with content fetched from the publishing CMS to keep launch messaging current.                       |
 | Add protected partner portal route   | 2025-09-19  | 2025-09-23      | 2025-09-23    | complete | Extend the router with a portal layout for authenticated label partners and resource downloads.                          |
-| Audit automation dependencies        | 2025-09-30  | 2025-09-30      | -             | planned  | Track guidogerbpublishing.com-specific config (npm scripts, workflow secrets, sitemap tooling) for the tenant generator. |
+| Audit automation dependencies        | 2025-09-30  | 2025-10-07      | 2025-10-07    | complete | Documented tenant-specific scripts, secrets, and sitemap config in `automation-touchpoints.json` with regression tests. |


### PR DESCRIPTION
## Summary
- add an automation-touchpoints.json inventory for guidogerbpublishing.com covering scripts, config, and manifests
- document the tracked automation touch points in the tenant README and mark the follow-up task complete
- add a regression test that verifies listed files exist and contain the expected domain or workspace slug references

## Testing
- pnpm --filter websites-guidogerbpublishing test

------
https://chatgpt.com/codex/tasks/task_e_68d5f18f6dc883249e9d6c013a51278f