### PR TITLE
Add automation touchpoints inventory for PickleCheeze

### DIFF
--- a/websites/picklecheeze.com/README.md
+++ b/websites/picklecheeze.com/README.md
@@ -50,5 +50,24 @@ pnpm --filter websites/picklecheeze.com build   # Production bundle
 pnpm --filter websites/picklecheeze.com preview # Preview the build locally
 ```
 
-Refer to [`tasks.md`](./tasks.md) for upcoming work such as branded 404 routes and feature flagging
-partner resources.
+## Automation touch points
+
+Automation and provisioning scripts still depend on hard-coded references to this
+tenant. The tracked inventory lives in
+[`automation-touchpoints.json`](./automation-touchpoints.json) and includes:
+
+- **Root scripts** — `package.json` surfaces `build:site:picklecheeze` and
+  `dev:site:picklecheeze` commands so CI can target this workspace.
+- **Site configuration** — `vite.config.js`, `generate-sitemap.mjs`, and the
+  published `public/sitemap.xml` embed the picklecheeze.com domain and local
+  hosts.
+- **Local development** — the CloudFront/S3 simulators (`infra/local-dev/*`) and
+  sync scripts restrict allowed hosts to `local.picklecheeze.com`.
+- **Secrets and runbooks** — `docs/CICD.md` and the seeded
+  `PICKLECHEEZE_VITE_ENV-secrets` file document the required environment
+  variables.
+- **Tenant manifest** — `infra/ps1/tenant-manifest.json` records the
+  `picklecheeze` workspace slug consumed by scaffolding automation.
+
+Refer to [`tasks.md`](./tasks.md) for upcoming work such as branded 404 routes and
+feature flagging partner resources.

--- a/websites/picklecheeze.com/automation-touchpoints.json
+++ b/websites/picklecheeze.com/automation-touchpoints.json
@@ -1,0 +1,52 @@
+{
+  "domain": "picklecheeze.com",
+  "workspaceSlug": "picklecheeze",
+  "touchPoints": [
+    {
+      "category": "root-scripts",
+      "check": "domain",
+      "paths": [
+        "package.json"
+      ],
+      "notes": "Root scripts reference the picklecheeze.com workspace for targeted build and dev commands."
+    },
+    {
+      "category": "site-config",
+      "check": "domain",
+      "paths": [
+        "websites/picklecheeze.com/vite.config.js",
+        "websites/picklecheeze.com/generate-sitemap.mjs",
+        "websites/picklecheeze.com/public/sitemap.xml"
+      ],
+      "notes": "Vite configuration, sitemap generation, and published assets embed the tenant domain and hosts."
+    },
+    {
+      "category": "local-development",
+      "check": "domain",
+      "paths": [
+        "infra/local-dev/cloudfront/nginx.conf",
+        "infra/local-dev/s3/nginx.conf",
+        "infra/local-dev/scripts/sync-sites.sh",
+        "infra/local-dev/README.md"
+      ],
+      "notes": "Local CloudFront/S3 simulators and sync scripts list the picklecheeze.com hostnames."
+    },
+    {
+      "category": "secrets",
+      "check": "domain",
+      "paths": [
+        "docs/CICD.md",
+        "websites/picklecheeze.com/PICKLECHEEZE_VITE_ENV-secrets"
+      ],
+      "notes": "Deployment runbooks and seed secret files encode the production domain."
+    },
+    {
+      "category": "tenant-manifest",
+      "check": "slug",
+      "paths": [
+        "infra/ps1/tenant-manifest.json"
+      ],
+      "notes": "Tenant provisioning manifest stores the workspace slug consumed by scaffolding scripts."
+    }
+  ]
+}

--- a/websites/picklecheeze.com/src/__tests__/automationTouchpoints.test.js
+++ b/websites/picklecheeze.com/src/__tests__/automationTouchpoints.test.js
@@ -1,0 +1,47 @@
+// @vitest-environment node
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const repoRoot = fileURLToPath(new URL('../../../../', import.meta.url))
+
+describe('picklecheeze.com automation touchpoints', () => {
+  const automationConfigPath = join(
+    repoRoot,
+    'websites/picklecheeze.com/automation-touchpoints.json',
+  )
+  const automationConfig = JSON.parse(readFileSync(automationConfigPath, 'utf8'))
+
+  it('tracks domain metadata and ensures listed files exist', () => {
+    const { domain, workspaceSlug, touchPoints } = automationConfig
+
+    expect(domain).toBe('picklecheeze.com')
+    expect(workspaceSlug).toBe('picklecheeze')
+    expect(Array.isArray(touchPoints)).toBe(true)
+    expect(touchPoints.length).toBeGreaterThan(0)
+
+    for (const touchPoint of touchPoints) {
+      expect(Array.isArray(touchPoint.paths)).toBe(true)
+      expect(touchPoint.paths.length).toBeGreaterThan(0)
+
+      for (const relativePath of touchPoint.paths) {
+        const absolutePath = join(repoRoot, relativePath)
+        const contents = readFileSync(absolutePath, 'utf8')
+
+        switch (touchPoint.check) {
+          case 'domain':
+            expect(contents).toContain(domain)
+            break
+          case 'slug':
+            expect(contents).toMatch(new RegExp(`\\b${workspaceSlug}\\b`, 'i'))
+            break
+          default:
+            throw new Error(
+              `Unknown touchpoint check '${touchPoint.check}' for ${relativePath}`,
+            )
+        }
+      }
+    }
+  })
+})

--- a/websites/picklecheeze.com/tasks.md
+++ b/websites/picklecheeze.com/tasks.md
@@ -5,4 +5,4 @@
 | Refresh site README and onboarding steps    | 2025-09-19  | 2025-09-19      | 2025-09-19    | complete | Documented tenant-specific copy, navigation, and environment variables for the fermentation partner portal.   |
 | Add dedicated 404 and maintenance routes    | 2025-09-19  | 2025-09-23      | 2025-09-23    | complete | Wire React Router fallback pages so broken links and downtime display branded messaging.                      |
 | Gate partner resources behind feature flags | 2025-09-19  | 2025-09-23      | 2025-09-23    | complete | Introduce runtime flags for welcome links and PDFs to support staged content launches.                        |
-| Prepare tenant for scaffolding automation   | 2025-09-30  | 2025-09-30      | -             | planned  | List the files that hard-code picklecheeze.com so the `AddCF-Tenant` script can update them programmatically. |
+| Prepare tenant for scaffolding automation   | 2025-09-30  | 2025-10-07      | 2025-10-07    | complete | Documented domain-specific files in `automation-touchpoints.json` and added regression tests to guard the inventory. |


### PR DESCRIPTION
## Summary
- capture picklecheeze.com automation references in a structured automation-touchpoints.json manifest
- document the tracked touch points in the tenant README and mark the task complete
- add a node-based regression test to ensure every listed file still references the tenant domain or slug

## Testing
- pnpm test:pickle

------
https://chatgpt.com/codex/tasks/task_e_68d6033f7ae483249f55d4eb1ba88bea