### PR TITLE
Add automation touchpoints inventory and tests for ggp.llc

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -571,6 +571,9 @@ importers:
       vite-plugin-mkcert:
         specifier: ^1.17.8
         version: 1.17.8(vite@7.1.7)
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(jsdom@27.0.0(postcss@8.5.6))
 
   websites/guidogerbpublishing.com:
     dependencies:

--- a/websites/ggp.llc/README.md
+++ b/websites/ggp.llc/README.md
@@ -37,5 +37,24 @@ pnpm --filter websites/ggp.llc build
 pnpm --filter websites/ggp.llc preview
 ```
 
+## Automation touch points
+
+Automation and provisioning scripts still hard-code references to this tenant. The
+tracked inventory lives in [`automation-touchpoints.json`](./automation-touchpoints.json)
+and includes:
+
+- **Root scripts** — the repo `package.json` exposes `build:site:ggp-llc` and
+  related commands so CI can target this workspace.
+- **Site configuration** — `generate-sitemap.mjs` and the published
+  `public/sitemap.xml` embed the production `ggp.llc` host.
+- **Preview hosts** — `vite.config.js` restricts HTTPS preview traffic to the
+  `llc.guidogerbpublishing.com` alias used during staging.
+- **Secrets and runbooks** — the seeded `GGP-LLC_VITE_ENV-secrets` file and
+  `docs/CICD.md` map the tenant to the correct environment secret.
+- **Local development** — CloudFront/S3 simulators in `infra/local-dev/*`
+  enumerate `local.ggp.llc` and related hostnames.
+- **Infrastructure** — `infra/ps1/cf-distributions.json` and the tenant manifest
+  keep the workspace slug available to provisioning scripts.
+
 See [`tasks.md`](./tasks.md) for next steps, including real marketing copy, portal routing, and branded
 error pages.

--- a/websites/ggp.llc/automation-touchpoints.json
+++ b/websites/ggp.llc/automation-touchpoints.json
@@ -1,0 +1,76 @@
+{
+  "domain": "ggp.llc",
+  "workspaceSlug": "ggp-llc",
+  "touchPoints": [
+    {
+      "category": "root-scripts",
+      "check": "domain",
+      "paths": [
+        "package.json"
+      ],
+      "notes": "Root scripts expose ggp.llc-specific workspace filters for CI and local builds."
+    },
+    {
+      "category": "site-config",
+      "check": "domain",
+      "paths": [
+        "websites/ggp.llc/generate-sitemap.mjs",
+        "websites/ggp.llc/public/sitemap.xml"
+      ],
+      "notes": "Sitemap generation and published XML embed the production domain and callback URLs."
+    },
+    {
+      "category": "preview-hosts",
+      "check": "match",
+      "match": "llc.guidogerbpublishing.com",
+      "paths": [
+        "websites/ggp.llc/vite.config.js"
+      ],
+      "notes": "Vite preview restricts HTTPS hosts to the guidogerbpublishing.com alias used for staging."
+    },
+    {
+      "category": "secrets",
+      "check": "match",
+      "match": "llm.guidogerbpublishing.com",
+      "paths": [
+        "websites/ggp.llc/GGP-LLC_VITE_ENV-secrets"
+      ],
+      "notes": "Seed secret file encodes the hosted UI and logout domains for automation to template."
+    },
+    {
+      "category": "deployment-runbooks",
+      "check": "domain",
+      "paths": [
+        "docs/CICD.md"
+      ],
+      "notes": "CI/CD documentation maps the tenant domain to its environment secret name."
+    },
+    {
+      "category": "local-development",
+      "check": "domain",
+      "paths": [
+        "infra/local-dev/cloudfront/nginx.conf",
+        "infra/local-dev/s3/nginx.conf",
+        "infra/local-dev/scripts/sync-sites.sh",
+        "infra/local-dev/README.md"
+      ],
+      "notes": "Local edge simulators and sync scripts enumerate the tenant hostnames."
+    },
+    {
+      "category": "infrastructure",
+      "check": "domain",
+      "paths": [
+        "infra/ps1/cf-distributions.json"
+      ],
+      "notes": "CloudFront distribution mappings associate the tenant domain with its distribution ID."
+    },
+    {
+      "category": "tenant-manifest",
+      "check": "slug",
+      "paths": [
+        "infra/ps1/tenant-manifest.json"
+      ],
+      "notes": "Tenant provisioning manifest records the workspace slug consumed by automation scripts."
+    }
+  ]
+}

--- a/websites/ggp.llc/package.json
+++ b/websites/ggp.llc/package.json
@@ -12,6 +12,8 @@
     "prepreview": "npm run build",
     "preview": "vite preview --strictPort",
     "lint": "pnpm exec eslint . --ext .js,.jsx --max-warnings=0",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "sitemap:dev": "node generate-sitemap.mjs development",
     "sitemap:prod": "node generate-sitemap.mjs production"
   },
@@ -43,6 +45,7 @@
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^16.3.0",
     "vite": "^7.1.2",
-    "vite-plugin-mkcert": "^1.17.8"
+    "vite-plugin-mkcert": "^1.17.8",
+    "vitest": "^3.2.4"
   }
 }

--- a/websites/ggp.llc/src/__tests__/automationTouchpoints.test.js
+++ b/websites/ggp.llc/src/__tests__/automationTouchpoints.test.js
@@ -1,0 +1,57 @@
+// @vitest-environment node
+import { readFileSync } from 'node:fs'
+import { isAbsolute, join, resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const repoRoot = resolve(process.cwd(), '..', '..')
+
+const readFile = (relativePath) =>
+  readFileSync(isAbsolute(relativePath) ? relativePath : join(repoRoot, relativePath), 'utf8')
+
+const normalizeMatches = (value) => {
+  if (!value) return []
+  if (Array.isArray(value)) return value.filter(Boolean)
+  return [value]
+}
+
+describe('ggp.llc automation touchpoints', () => {
+  const automationConfigPath = join(repoRoot, 'websites/ggp.llc/automation-touchpoints.json')
+  const automationConfig = JSON.parse(readFile(automationConfigPath))
+
+  it('tracks domain metadata and ensures listed files exist', () => {
+    const { domain, workspaceSlug, touchPoints } = automationConfig
+
+    expect(domain).toBe('ggp.llc')
+    expect(workspaceSlug).toBe('ggp-llc')
+    expect(Array.isArray(touchPoints)).toBe(true)
+    expect(touchPoints.length).toBeGreaterThan(0)
+
+    for (const touchPoint of touchPoints) {
+      expect(Array.isArray(touchPoint.paths)).toBe(true)
+      expect(touchPoint.paths.length).toBeGreaterThan(0)
+
+      for (const relativePath of touchPoint.paths) {
+        const contents = readFile(relativePath)
+        const matches = normalizeMatches(touchPoint.match)
+
+        if (matches.length > 0) {
+          for (const pattern of matches) {
+            expect(contents).toContain(pattern)
+          }
+          continue
+        }
+
+        switch (touchPoint.check) {
+          case 'domain':
+            expect(contents).toContain(domain)
+            break
+          case 'slug':
+            expect(contents).toMatch(new RegExp(`\\b${workspaceSlug}\\b`, 'i'))
+            break
+          default:
+            throw new Error(`Unknown touchpoint check '${touchPoint.check}' for ${relativePath}`)
+        }
+      }
+    }
+  })
+})

--- a/websites/ggp.llc/tasks.md
+++ b/websites/ggp.llc/tasks.md
@@ -5,4 +5,4 @@
 | Replace SPEC excerpt with site README   | 2025-09-19  | 2025-09-19      | 2025-09-19    | complete | Rewrote documentation to describe the regulatory platform microsite instead of embedding the full spec.                   |
 | Author public overview content          | 2025-09-19  | 2025-09-24      | 2025-09-24    | complete | Drafted a regulator-focused marketing narrative with modernization pillars and clear calls to action.                     |
 | Add router fallback + maintenance pages | 2025-09-19  | 2025-09-25      | 2025-09-25    | complete | Provide 404/503 experiences aligned with the compliance-focused brand.                                                    |
-| Enumerate automation configuration      | 2025-09-30  | 2025-09-30      | -             | planned  | Document ggp.llc-specific build flags (LLC domain handling, preview hostnames, secrets) for the tenant generator backlog. |
+| Enumerate automation configuration      | 2025-09-30  | 2025-10-07      | 2025-10-07    | complete | Documented ggp.llc domain + alias hosts in `automation-touchpoints.json` and added tests to guard the inventory. |


### PR DESCRIPTION
## Summary
- add an automation-touchpoints.json inventory for ggp.llc covering domain, preview hosts, secrets, and infra references
- document the new automation inventory in the tenant README and mark the backlog task complete
- wire Vitest scripts for the tenant and add a regression test that validates every tracked file contains the expected domain or alias values

## Testing
- pnpm --filter websites-ggp-llc test -- --run --reporter=basic

------
https://chatgpt.com/codex/tasks/task_e_68d606a75348832494589c70efe33555