### PR TITLE
Fix collectPaginatedResults onPage context cursor handling

### DIFF
--- a/@guidogerb/components/api-client/src/__tests__/pagination.test.js
+++ b/@guidogerb/components/api-client/src/__tests__/pagination.test.js
@@ -167,8 +167,11 @@ describe('collectPaginatedResults', () => {
     await collectPaginatedResults({ fetchPage, onPage, initialParams: { limit: 10 } })
 
     expect(onPage).toHaveBeenCalledTimes(2)
-    const [[, context]] = onPage.mock.calls
-    expect(Object.isFrozen(context.params)).toBe(true)
-    expect(context.params).toEqual({ limit: 10 })
+    const [[, firstContext], [, secondContext]] = onPage.mock.calls
+    expect(Object.isFrozen(firstContext.params)).toBe(true)
+    expect(firstContext.params).toEqual({ limit: 10 })
+    expect(firstContext.cursor).toBeNull()
+    expect(secondContext.cursor).toBe('cursor-1')
+    expect(secondContext.params).toEqual({ limit: 10, cursor: 'cursor-1' })
   })
 })

--- a/@guidogerb/components/api-client/src/pagination.js
+++ b/@guidogerb/components/api-client/src/pagination.js
@@ -170,6 +170,7 @@ export const collectPaginatedResults = async ({
     if (typeof onPage === 'function') {
       await onPage(result, {
         page: pageNumber,
+        cursor: cursorForNextPage,
         params: Object.freeze({ ...paramsForRequest }),
       })
     }


### PR DESCRIPTION
## Summary
- include the active cursor in collectPaginatedResults onPage callback context
- expand pagination tests to assert cursor and params snapshots across pages

## Testing
- pnpm --filter "@guidogerb/components-api" test

------
https://chatgpt.com/codex/tasks/task_e_68d60a729e6483248e7eecb329f2bd33