### PR TITLE
Fix useDebounceFunc debounce timing and add tests

### DIFF
--- a/@guidogerb/hooks/__tests__/useDebounceFunc.test.js
+++ b/@guidogerb/hooks/__tests__/useDebounceFunc.test.js
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { useDebounceFunc } from '../useDebounceFunc.js'
+
+describe('useDebounceFunc', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers()
+    vi.clearAllTimers()
+    vi.useRealTimers()
+    vi.clearAllMocks()
+  })
+
+  it('invokes the callback immediately when the cooldown has passed and resolves the returned promise', async () => {
+    const callback = vi.fn()
+    const { result } = renderHook(() => useDebounceFunc(callback, 200))
+
+    const firstPromise = result.current('first')
+    await expect(firstPromise).resolves.toBe('first')
+
+    expect(callback).toHaveBeenCalledTimes(1)
+    expect(callback).toHaveBeenCalledWith('first')
+
+    vi.advanceTimersByTime(250)
+
+    const secondPromise = result.current('second')
+    await expect(secondPromise).resolves.toBe('second')
+
+    expect(callback).toHaveBeenCalledTimes(2)
+    expect(callback).toHaveBeenLastCalledWith('second')
+  })
+
+  it('queues calls made during the cooldown and resolves with the latest value', async () => {
+    const callback = vi.fn()
+    const { result } = renderHook(() => useDebounceFunc(callback, 200))
+
+    const firstPromise = result.current('initial')
+    await expect(firstPromise).resolves.toBe('initial')
+
+    expect(callback).toHaveBeenCalledTimes(1)
+
+    const secondPromise = result.current('queued')
+
+    expect(callback).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(200)
+
+    expect(callback).toHaveBeenCalledTimes(2)
+    expect(callback).toHaveBeenLastCalledWith('queued')
+    await expect(secondPromise).resolves.toBe('queued')
+  })
+})

--- a/@guidogerb/hooks/useDebounceFunc.js
+++ b/@guidogerb/hooks/useDebounceFunc.js
@@ -19,25 +19,26 @@ export function useDebounceFunc(func, delay = 1000) {
   return useCallback(
     (param) => {
       const promise = new Promise((resolve) => {
-        if (
-          !lastInvocationRef.current ||
-          lastInvocationRef.current - new Date().getTime() >= delay
-        ) {
+        const now = new Date().getTime()
+
+        if (!lastInvocationRef.current || now - lastInvocationRef.current >= delay) {
           clearTimeout(timeoutRef.current)
-          lastInvocationRef.current = new Date().getTime()
+          lastInvocationRef.current = now
           lastVarArgsRef.current = null
           func(param)
-        } else {
-          lastVarArgsRef.current = param
-          lastInvocationRef.current = new Date().getTime()
-          clearTimeout(timeoutRef.current)
-          timeoutRef.current = window.setTimeout(() => {
-            func(lastVarArgsRef.current)
-            lastVarArgsRef.current = null
-            lastInvocationRef.current = NaN
-            resolve(param)
-          }, delay)
+          resolve(param)
+          return
         }
+
+        lastVarArgsRef.current = param
+        lastInvocationRef.current = now
+        clearTimeout(timeoutRef.current)
+        timeoutRef.current = window.setTimeout(() => {
+          func(lastVarArgsRef.current)
+          lastVarArgsRef.current = null
+          lastInvocationRef.current = NaN
+          resolve(param)
+        }, delay)
       })
       return promise
     },


### PR DESCRIPTION
## Summary
- correct the cooldown comparison in useDebounceFunc and resolve the returned promise when the callback fires immediately
- keep pending invocations queued with the latest value and add unit tests covering immediate and delayed executions

## Testing
- pnpm --filter @guidogerb/hooks test

------
https://chatgpt.com/codex/tasks/task_e_68d60f9b263083248858b0bea6416541