### PR TITLE
Restore AddCF tenant provisioning script execution

### DIFF
--- a/infra/ps1/AddCF-Tenant.ps1
+++ b/infra/ps1/AddCF-Tenant.ps1
@@ -47,7 +47,6 @@
   validated inputs.
 #>
 
-<#
 [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
 param(
     [Parameter(Mandatory = $true)]
@@ -1405,4 +1404,3 @@ Update-TenantManifest -RepoRoot $repoRoot -Tenant $tenant -EnvSecretKeys $normal
 
 $result['Scaffolded'] = $true
 Write-Output ([pscustomobject]$result)
-#>


### PR DESCRIPTION
## Summary
- remove the stray block comment that wrapped `AddCF-Tenant.ps1`, allowing the provisioning script to run again

## Testing
- pnpm vitest run websites/picklecheeze.com/src/__tests__/App.test.jsx
- pnpm vitest run websites/ggp.llc/src/__tests__/App.test.jsx
- pnpm vitest run infra/scripts/__tests__/addcf-tenant.integration.test.mjs


------
https://chatgpt.com/codex/tasks/task_e_68d61158108483248de2d5b5da9f3121