### PR TITLE
Add automation readiness task breakdown

### DIFF
--- a/docs/test/automation-readiness-plan.md
+++ b/docs/test/automation-readiness-plan.md
@@ -1,0 +1,14 @@
+# Automation Readiness Task Breakdown
+
+The following tasks divide the work required to implement automation readiness across all tenant websites, finalize `<AppBasic />` automation defaults, execute the documented test backlog, and ensure `<AppBasic />` is installed for each tenant application.
+
+1. **Finalize `<AppBasic />` automation defaults** – Document and implement the baseline configuration (providers, environment flags, and CI hooks) required for automated smoke, regression, and install flows across all tenants.
+2. **Create reusable automation scaffolding** – Build shared scripts or packages that install `<AppBasic />`, configure feature flags, seed tenant-specific data, and provide fixtures for end-to-end runs.
+3. **Update `websites/garygerber.com` for automation readiness** – Install `<AppBasic />`, wire the shared automation scaffolding, and prepare route smoke tests aligned with the backlog follow-ups.
+4. **Update `websites/guidogerbpublishing.com` for automation readiness** – Install `<AppBasic />`, connect automation scaffolding, and stage catalog submission test placeholders according to the backlog.
+5. **Update `websites/picklecheeze.com` for automation readiness** – Install `<AppBasic />`, integrate automation scaffolding, and capture analytics event hooks for the planned automation coverage.
+6. **Update `websites/this-is-my-story.org` for automation readiness** – Install `<AppBasic />`, integrate automation scaffolding, and prepare story submission automation entry points per the backlog.
+7. **Update `websites/stream4cloud.com` for automation readiness** – Install `<AppBasic />`, bootstrap the landing page shell, and add the initial automation tests defined in the backlog for hero, CTA, and routing guards.
+8. **Implement shared test utilities** – Deliver the shared Vitest utilities (render wrapper, auth context factory, storage mocks) described in the backlog so tenant and component suites can use consistent helpers.
+9. **Automate cross-tenant CI validation** – Configure pipelines to run install/build/test checks (clean, install, build, lint, format, preview smoke) using the `<AppBasic />` automation defaults for every tenant package.
+10. **Track coverage metrics and backlog follow-up** – Enable coverage reporting thresholds and document future automation milestones per package, keeping the backlog synchronized with execution status.


### PR DESCRIPTION
## Summary
- add a plan that divides the automation readiness and `<AppBasic />` installation work into ten tasks
- align tasks with tenant websites and shared testing backlog priorities

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d68b6b6bb483248f35822304e08c53