### PR TITLE
feat(app): add automation scaffolding helpers

### DIFF
--- a/@guidogerb/components/app/README.md
+++ b/@guidogerb/components/app/README.md
@@ -48,6 +48,37 @@ defaults representative ensures fresh tenants boot with a working shell. Overrid
 header, footer, authentication, API client, storage, service worker, theming, and page collections
 through the component props.
 
+### Automation helpers
+
+Automation workflows can inspect the shared defaults and bootstrap tenant plans through the new
+helpers exported from this package:
+
+```js
+import {
+  APP_BASIC_AUTOMATION_DEFAULTS,
+  createAppBasicAutomationScaffold,
+} from '@guidogerb/components-app'
+
+const scaffold = createAppBasicAutomationScaffold({
+  tenant: {
+    domain: 'stories.example.com',
+    displayName: 'Stories Example',
+    supportEmail: 'help@example.com',
+  },
+  env: {
+    VITE_API_BASE_URL: 'https://api.stories.example/',
+  },
+})
+
+console.log(scaffold.environment.VITE_REDIRECT_URI)
+// -> https://stories.example.com/auth/callback
+```
+
+- **`APP_BASIC_AUTOMATION_DEFAULTS`** documents the provider order, layout regions, CI commands, and
+  environment variables automation must seed when generating a tenant.
+- **`createAppBasicAutomationScaffold(options)`** merges tenant metadata, environment overrides, and
+  optional plan customisations before returning a ready-to-use `<AppBasic />` plan.
+
 #### Blueprint & planning helpers
 
 `@guidogerb/components-app` now exports metadata describing the shared shell contract so new

--- a/@guidogerb/components/app/index.js
+++ b/@guidogerb/components/app/index.js
@@ -1,3 +1,7 @@
 export { App, AppBasic, useAppApiClient, useAppBasicContext } from './src/App.jsx'
 export { App as default } from './src/App.jsx'
 export { APP_VARIANT_SPECS, getAppVariantSpec, listAppVariantSpecs } from './src/variantSpecs.js'
+export {
+  APP_BASIC_AUTOMATION_DEFAULTS,
+  createAppBasicAutomationScaffold,
+} from './src/automation.js'

--- a/@guidogerb/components/app/src/__tests__/automation.test.js
+++ b/@guidogerb/components/app/src/__tests__/automation.test.js
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest'
+
+import { APP_BASIC_AUTOMATION_DEFAULTS, createAppBasicAutomationScaffold } from '../automation.js'
+
+describe('APP_BASIC_AUTOMATION_DEFAULTS', () => {
+  it('documents provider order, layout regions, CI commands, and environment variables', () => {
+    expect(Object.isFrozen(APP_BASIC_AUTOMATION_DEFAULTS)).toBe(true)
+    expect(APP_BASIC_AUTOMATION_DEFAULTS.providerOrder).toEqual(['storage', 'auth', 'header', 'ui'])
+    expect(APP_BASIC_AUTOMATION_DEFAULTS.layoutRegions.map((region) => region.id)).toEqual([
+      'header',
+      'main',
+      'footer',
+    ])
+    expect(APP_BASIC_AUTOMATION_DEFAULTS.ci.commands).toEqual(
+      expect.arrayContaining(['pnpm clean', 'pnpm install', 'pnpm build', 'pnpm lint', 'pnpm test']),
+    )
+    const variableKeys = APP_BASIC_AUTOMATION_DEFAULTS.environment.variables.map((variable) => variable.key)
+    expect(variableKeys).toEqual(
+      expect.arrayContaining([
+        'VITE_SITE_DOMAIN',
+        'VITE_API_BASE_URL',
+        'VITE_COGNITO_AUTHORITY',
+        'VITE_COGNITO_CLIENT_ID',
+        'VITE_LOGIN_CALLBACK_PATH',
+        'VITE_REDIRECT_URI',
+        'VITE_ENABLE_SW',
+      ]),
+    )
+  })
+})
+
+describe('createAppBasicAutomationScaffold', () => {
+  it('produces a tenant-aware plan and environment defaults', () => {
+    const scaffold = createAppBasicAutomationScaffold({
+      tenant: {
+        domain: 'stories.example.com',
+        displayName: 'Stories Example',
+        supportEmail: 'help@example.com',
+      },
+    })
+
+    expect(scaffold.tenant).toEqual(
+      expect.objectContaining({
+        domain: 'stories.example.com',
+        displayName: 'Stories Example',
+        supportEmail: 'help@example.com',
+      }),
+    )
+
+    expect(scaffold.environment).toEqual(
+      expect.objectContaining({
+        VITE_SITE_DOMAIN: 'stories.example.com',
+        VITE_SITE_URL: 'https://stories.example.com',
+        VITE_REDIRECT_URI: 'https://stories.example.com/auth/callback',
+        VITE_LOGOUT_URI: 'https://stories.example.com/auth/logout',
+        VITE_SUPPORT_EMAIL: 'help@example.com',
+      }),
+    )
+
+    expect(scaffold.plan.variant).toBe('basic')
+    expect(scaffold.plan.navigation.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'support', href: 'mailto:help@example.com', external: true }),
+      ]),
+    )
+  })
+
+  it('honours environment and plan overrides when generating the scaffold', () => {
+    const scaffold = createAppBasicAutomationScaffold({
+      tenant: { domain: 'tenant.example.com' },
+      env: {
+        VITE_API_BASE_URL: 'https://api.tenant.example/',
+        VITE_ENABLE_SW: 'true',
+      },
+      planOverrides: {
+        serviceWorker: { url: '/custom-sw.js' },
+      },
+    })
+
+    expect(scaffold.environment).toEqual(
+      expect.objectContaining({
+        VITE_API_BASE_URL: 'https://api.tenant.example/',
+        VITE_ENABLE_SW: 'true',
+        VITE_SW_URL: '/custom-sw.js',
+      }),
+    )
+
+    expect(scaffold.plan.serviceWorker).toEqual(
+      expect.objectContaining({ enabled: true, url: '/custom-sw.js' }),
+    )
+    expect(scaffold.plan.api).toEqual(expect.objectContaining({ baseUrl: 'https://api.tenant.example/' }))
+  })
+})

--- a/@guidogerb/components/app/src/automation.js
+++ b/@guidogerb/components/app/src/automation.js
@@ -1,0 +1,350 @@
+import {
+  APP_BASIC_DEFAULTS,
+  APP_BASIC_TENANT_CONTROLS,
+  APP_SHELL_LAYOUT_BLUEPRINT,
+  APP_SHELL_PROVIDER_BLUEPRINT,
+  createAppBasicPlan,
+} from './App.jsx'
+
+const DEFAULT_AUTOMATION_DOMAIN = 'tenant.example.com'
+const DEFAULT_AUTOMATION_DISPLAY_NAME = 'Guidogerb Tenant'
+const DEFAULT_AUTOMATION_SUPPORT_EMAIL = 'support@guidogerb.com'
+const DEFAULT_AUTOMATION_TAGLINE = 'Stories in motion for modern audiences.'
+const DEFAULT_AUTOMATION_LOGOUT_PATH = '/auth/logout'
+
+const DEFAULT_AUTOMATION_NAVIGATION_ITEMS = Object.freeze([
+  { id: 'home', label: 'Home', href: '/' },
+  { id: 'dashboard', label: 'Dashboard', href: '/dashboard' },
+  { id: 'support', label: 'Support', href: `mailto:${DEFAULT_AUTOMATION_SUPPORT_EMAIL}`, external: true },
+])
+
+const DEFAULT_AUTOMATION_CI_COMMANDS = Object.freeze([
+  'pnpm clean',
+  'pnpm install',
+  'pnpm build',
+  'pnpm lint',
+  'pnpm format:check',
+  'pnpm test',
+])
+
+const deepFreeze = (value) => {
+  if (Array.isArray(value)) {
+    for (const entry of value) deepFreeze(entry)
+    return Object.freeze(value)
+  }
+  if (value && typeof value === 'object') {
+    for (const entry of Object.values(value)) deepFreeze(entry)
+    return Object.freeze(value)
+  }
+  return value
+}
+
+const copyBlueprintOrder = () => [...APP_SHELL_PROVIDER_BLUEPRINT.order]
+
+const copyLayoutRegions = () =>
+  APP_SHELL_LAYOUT_BLUEPRINT.regions.map((region) => ({
+    id: region.id,
+    role: region.role,
+    description: region.description,
+  }))
+
+const ENVIRONMENT_VARIABLES = Object.freeze([
+  {
+    key: 'VITE_SITE_DOMAIN',
+    required: true,
+    description:
+      'Primary domain served by the tenant. Used to derive canonical URLs, redirect URIs, and preview hosts.',
+  },
+  {
+    key: 'VITE_SITE_URL',
+    required: false,
+    description: 'Fully qualified site URL. Defaults to https://{VITE_SITE_DOMAIN} when omitted.',
+  },
+  {
+    key: 'VITE_SUPPORT_EMAIL',
+    required: false,
+    description: 'Contact email surfaced in navigation and footer support links.',
+  },
+  {
+    key: 'VITE_API_BASE_URL',
+    required: false,
+    description: 'Overrides the shared API base URL consumed by @guidogerb/components-api.',
+  },
+  {
+    key: 'VITE_COGNITO_AUTHORITY',
+    required: true,
+    description: 'OIDC authority/issuer URL consumed by the shared authentication provider.',
+  },
+  {
+    key: 'VITE_COGNITO_METADATA_URL',
+    required: false,
+    description: 'Optional discovery metadata URL for tenants that publish a non-standard OIDC document.',
+  },
+  {
+    key: 'VITE_COGNITO_CLIENT_ID',
+    required: true,
+    description: 'OIDC client identifier used by the hosted UI login flow.',
+  },
+  {
+    key: 'VITE_COGNITO_SCOPE',
+    required: false,
+    description: 'OIDC scopes requested during authentication. Defaults to "openid profile email".',
+  },
+  {
+    key: 'VITE_RESPONSE_TYPE',
+    required: false,
+    description: 'OIDC response type requested from Cognito. Defaults to "code".',
+  },
+  {
+    key: 'VITE_LOGIN_CALLBACK_PATH',
+    required: false,
+    description: 'Path appended to the site URL for OIDC login callbacks. Defaults to /auth/callback.',
+  },
+  {
+    key: 'VITE_REDIRECT_URI',
+    required: false,
+    description: 'Explicit login redirect URI. Derived from VITE_SITE_URL + VITE_LOGIN_CALLBACK_PATH by default.',
+  },
+  {
+    key: 'VITE_COGNITO_POST_LOGOUT_REDIRECT_URI',
+    required: false,
+    description:
+      'Redirect URI Cognito invokes after logout. Defaults to the site URL with the shared /auth/logout path.',
+  },
+  {
+    key: 'VITE_LOGOUT_URI',
+    required: false,
+    description: 'Frontend logout URL routed through AppBasic. Defaults to the shared /auth/logout path.',
+  },
+  {
+    key: 'VITE_ENABLE_SW',
+    required: false,
+    description: 'When "true", registers the shared service worker during automation smoke tests.',
+  },
+  {
+    key: 'VITE_SW_URL',
+    required: false,
+    description: 'Custom service worker URL registered when automation enables offline support.',
+  },
+])
+
+const cloneNavigationItems = (supportEmail) =>
+  DEFAULT_AUTOMATION_NAVIGATION_ITEMS.map((item) => {
+    if (item.id !== 'support') return { ...item }
+    const email = typeof supportEmail === 'string' && supportEmail.trim().length > 0
+      ? supportEmail.trim()
+      : DEFAULT_AUTOMATION_SUPPORT_EMAIL
+    return { ...item, href: `mailto:${email}` }
+  })
+
+const ensureString = (value) => (typeof value === 'string' ? value.trim() : '')
+
+const ensurePath = (value, fallback) => {
+  const trimmed = ensureString(value)
+  if (!trimmed) return fallback
+  return trimmed.startsWith('/') ? trimmed : `/${trimmed}`
+}
+
+const stripTrailingSlash = (value) => value.replace(/\/+$/, '') || value
+
+const coerceBoolean = (value, fallback) => {
+  if (typeof value === 'boolean') return value
+  if (value === undefined || value === null) return fallback
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase()
+    if (normalized === 'true') return true
+    if (normalized === 'false') return false
+  }
+  return fallback
+}
+
+const buildEnvironmentMap = ({
+  domain,
+  siteUrl,
+  supportEmail,
+  apiBaseUrl,
+  authority,
+  metadataUrl,
+  clientId,
+  scope,
+  responseType,
+  loginCallbackPath,
+  redirectUri,
+  postLogoutRedirectUri,
+  logoutUri,
+  serviceWorkerEnabled,
+  serviceWorkerUrl,
+}) => {
+  return {
+    VITE_SITE_DOMAIN: domain,
+    VITE_SITE_URL: siteUrl,
+    VITE_SUPPORT_EMAIL: supportEmail,
+    VITE_API_BASE_URL: apiBaseUrl,
+    VITE_COGNITO_AUTHORITY: authority,
+    VITE_COGNITO_METADATA_URL: metadataUrl ?? '',
+    VITE_COGNITO_CLIENT_ID: clientId,
+    VITE_COGNITO_SCOPE: scope,
+    VITE_RESPONSE_TYPE: responseType,
+    VITE_LOGIN_CALLBACK_PATH: loginCallbackPath,
+    VITE_REDIRECT_URI: redirectUri,
+    VITE_COGNITO_POST_LOGOUT_REDIRECT_URI: postLogoutRedirectUri,
+    VITE_LOGOUT_URI: logoutUri,
+    VITE_ENABLE_SW: serviceWorkerEnabled ? 'true' : 'false',
+    VITE_SW_URL: serviceWorkerUrl,
+  }
+}
+
+const rawAutomationDefaults = {
+  variant: 'basic',
+  providerOrder: copyBlueprintOrder(),
+  layoutRegions: copyLayoutRegions(),
+  tenantControls: APP_BASIC_TENANT_CONTROLS,
+  environment: {
+    variables: ENVIRONMENT_VARIABLES,
+  },
+  ci: {
+    commands: DEFAULT_AUTOMATION_CI_COMMANDS,
+  },
+  notes: [
+    'Use createAppBasicAutomationScaffold to derive tenant plans consumed by <AppBasic /> during automation.',
+    'Environment variables default to the shared Guidogerb infrastructure but can be overridden per tenant.',
+  ],
+}
+
+export const APP_BASIC_AUTOMATION_DEFAULTS = deepFreeze(rawAutomationDefaults)
+
+export const createAppBasicAutomationScaffold = ({
+  tenant = {},
+  env = {},
+  planOverrides = {},
+} = {}) => {
+  const tenantDomain = ensureString(env.VITE_SITE_DOMAIN) || ensureString(tenant.domain)
+  const domain = tenantDomain || DEFAULT_AUTOMATION_DOMAIN
+
+  const rawSiteUrl = ensureString(env.VITE_SITE_URL)
+  const siteUrl = stripTrailingSlash(rawSiteUrl || `https://${domain}`)
+
+  const loginCallbackPath = ensurePath(
+    env.VITE_LOGIN_CALLBACK_PATH,
+    APP_BASIC_DEFAULTS.auth.loginCallbackPath || '/auth/callback',
+  )
+  const redirectUri = ensureString(env.VITE_REDIRECT_URI) || `${siteUrl}${loginCallbackPath}`
+
+  const supportEmail = ensureString(env.VITE_SUPPORT_EMAIL) || ensureString(tenant.supportEmail) || DEFAULT_AUTOMATION_SUPPORT_EMAIL
+
+  const authority = ensureString(env.VITE_COGNITO_AUTHORITY) || APP_BASIC_DEFAULTS.auth.authority
+  const metadataUrl = ensureString(env.VITE_COGNITO_METADATA_URL) || undefined
+  const clientId = ensureString(env.VITE_COGNITO_CLIENT_ID) || APP_BASIC_DEFAULTS.auth.client_id
+  const scope = ensureString(env.VITE_COGNITO_SCOPE) || APP_BASIC_DEFAULTS.auth.scope
+  const responseType = ensureString(env.VITE_RESPONSE_TYPE) || APP_BASIC_DEFAULTS.auth.response_type
+
+  const postLogoutRedirectUri =
+    ensureString(env.VITE_COGNITO_POST_LOGOUT_REDIRECT_URI) || `${siteUrl}${DEFAULT_AUTOMATION_LOGOUT_PATH}`
+  const logoutUri = ensureString(env.VITE_LOGOUT_URI) || postLogoutRedirectUri
+
+  const apiBaseUrl = ensureString(env.VITE_API_BASE_URL) || APP_BASIC_DEFAULTS.api.baseUrl
+
+  const serviceWorkerEnabled = coerceBoolean(env.VITE_ENABLE_SW, APP_BASIC_DEFAULTS.serviceWorker.enabled)
+  const serviceWorkerUrl = ensureString(env.VITE_SW_URL) || APP_BASIC_DEFAULTS.serviceWorker.url
+
+  const displayName = ensureString(tenant.displayName) || DEFAULT_AUTOMATION_DISPLAY_NAME
+
+  const baseConfig = {
+    api: {
+      baseUrl: apiBaseUrl,
+    },
+    auth: {
+      authority,
+      metadataUrl,
+      clientId,
+      redirectUri,
+      responseType,
+      scope,
+      postLogoutRedirectUri,
+      logoutUri,
+    },
+    navigation: {
+      items: cloneNavigationItems(supportEmail),
+    },
+    header: {
+      settings: {
+        brand: {
+          title: displayName,
+          tagline: DEFAULT_AUTOMATION_TAGLINE,
+          href: '/',
+        },
+      },
+    },
+    footer: {
+      brand: { name: displayName, href: '/' },
+      description: 'Replace this placeholder copy with tenant-specific storytelling highlights.',
+      socialLinks: [{ label: 'Email', href: `mailto:${supportEmail}`, external: true }],
+      legalLinks: [
+        { label: 'Privacy Policy', href: '/privacy' },
+        { label: 'Terms of Service', href: '/terms' },
+      ],
+    },
+    serviceWorker: {
+      enabled: serviceWorkerEnabled,
+      url: serviceWorkerUrl,
+    },
+  }
+
+  const mergedConfig = {
+    ...planOverrides,
+    api: { ...baseConfig.api, ...(planOverrides.api ?? {}) },
+    auth: { ...baseConfig.auth, ...(planOverrides.auth ?? {}) },
+    navigation: { ...baseConfig.navigation, ...(planOverrides.navigation ?? {}) },
+    header: {
+      ...baseConfig.header,
+      ...(planOverrides.header ?? {}),
+      settings: {
+        ...(baseConfig.header?.settings ?? {}),
+        ...(planOverrides.header?.settings ?? {}),
+        brand: {
+          ...(baseConfig.header?.settings?.brand ?? {}),
+          ...(planOverrides.header?.settings?.brand ?? {}),
+        },
+      },
+    },
+    footer: { ...baseConfig.footer, ...(planOverrides.footer ?? {}) },
+    serviceWorker: { ...baseConfig.serviceWorker, ...(planOverrides.serviceWorker ?? {}) },
+  }
+
+  const plan = createAppBasicPlan(mergedConfig)
+
+  const environment = buildEnvironmentMap({
+    domain,
+    siteUrl,
+    supportEmail,
+    apiBaseUrl: plan.api.baseUrl ?? apiBaseUrl,
+    authority: plan.providers.auth.props.authority ?? authority,
+    metadataUrl,
+    clientId: plan.providers.auth.props.client_id,
+    scope: plan.providers.auth.props.scope,
+    responseType: plan.providers.auth.props.response_type,
+    loginCallbackPath,
+    redirectUri: plan.providers.auth.props.redirect_uri,
+    postLogoutRedirectUri: plan.providers.auth.props.post_logout_redirect_uri,
+    logoutUri: plan.providers.auth.logoutUri,
+    serviceWorkerEnabled: plan.serviceWorker.enabled,
+    serviceWorkerUrl: plan.serviceWorker.url,
+  })
+
+  return {
+    tenant: {
+      domain,
+      displayName,
+      supportEmail,
+    },
+    environment,
+    ci: APP_BASIC_AUTOMATION_DEFAULTS.ci,
+    plan,
+    summary: {
+      providerOrder: plan.providerBlueprint.order,
+      layoutRegions: plan.layoutBlueprint.regions.map((region) => region.id),
+    },
+  }
+}
+
+export default createAppBasicAutomationScaffold


### PR DESCRIPTION
## Summary
- document the new AppBasic automation helpers in the package README
- expose automation defaults and scaffolding utilities from the component entrypoint
- implement automation defaults/scaffold helpers with unit tests covering the new behaviour

## Testing
- pnpm --filter "@guidogerb/components-app" test

------
https://chatgpt.com/codex/tasks/task_e_68d6910740b08324ae49044f4a2d45b1